### PR TITLE
Support Clone operation on the client

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -38,6 +38,7 @@ use tonic::Interceptor;
 const HTTP_PREFIX: &str = "http://";
 
 /// Asynchronous `etcd` client using v3 API.
+#[derive(Clone)]
 pub struct Client {
     kv: KvClient,
     watch: WatchClient,

--- a/src/rpc/auth.rs
+++ b/src/rpc/auth.rs
@@ -38,6 +38,7 @@ use tonic::{Interceptor, IntoRequest, Request};
 
 /// Client for Auth operations.
 #[repr(transparent)]
+#[derive(Clone)]
 pub struct AuthClient {
     inner: PbAuthClient<Channel>,
 }

--- a/src/rpc/cluster.rs
+++ b/src/rpc/cluster.rs
@@ -17,6 +17,7 @@ use tonic::{Interceptor, IntoRequest, Request};
 
 /// Client for Cluster operations.
 #[repr(transparent)]
+#[derive(Clone)]
 pub struct ClusterClient {
     inner: PbClusterClient<Channel>,
 }

--- a/src/rpc/election.rs
+++ b/src/rpc/election.rs
@@ -17,6 +17,7 @@ use tonic::{Interceptor, IntoRequest, Request, Streaming};
 
 /// Client for Elect operations.
 #[repr(transparent)]
+#[derive(Clone)]
 pub struct ElectionClient {
     inner: PbElectionClient<Channel>,
 }

--- a/src/rpc/kv.rs
+++ b/src/rpc/kv.rs
@@ -22,6 +22,7 @@ use tonic::{Interceptor, IntoRequest, Request};
 
 /// Client for KV operations.
 #[repr(transparent)]
+#[derive(Clone)]
 pub struct KvClient {
     inner: PbKvClient<Channel>,
 }

--- a/src/rpc/lease.rs
+++ b/src/rpc/lease.rs
@@ -24,6 +24,7 @@ use tonic::{Interceptor, IntoRequest, Request, Streaming};
 
 /// Client for lease operations.
 #[repr(transparent)]
+#[derive(Clone)]
 pub struct LeaseClient {
     inner: PbLeaseClient<Channel>,
 }

--- a/src/rpc/lock.rs
+++ b/src/rpc/lock.rs
@@ -15,6 +15,7 @@ use tonic::{Interceptor, IntoRequest, Request};
 
 /// Client for Lock operations.
 #[repr(transparent)]
+#[derive(Clone)]
 pub struct LockClient {
     inner: PbLockClient<Channel>,
 }

--- a/src/rpc/maintenance.rs
+++ b/src/rpc/maintenance.rs
@@ -23,6 +23,7 @@ use tonic::{Interceptor, IntoRequest, Request};
 
 /// Client for maintenance operations.
 #[repr(transparent)]
+#[derive(Clone)]
 pub struct MaintenanceClient {
     inner: PbMaintenanceClient<Channel>,
 }

--- a/src/rpc/watch.rs
+++ b/src/rpc/watch.rs
@@ -20,6 +20,7 @@ use tonic::{Interceptor, Streaming};
 
 /// Client for watch operations.
 #[repr(transparent)]
+#[derive(Clone)]
 pub struct WatchClient {
     inner: PbWatchClient<Channel>,
 }


### PR DESCRIPTION
In the Tonic ecosystem, the primary way of sharing a client between
multiple contexts is to clone. The client itself is usually a thin
wrapper over a channel, and the channel itself is meant to be cloned to
support sharing.

All the rpc specific clients and the global client now support cloning
for sharing.