### PR TITLE
Support TLS connection with optional tonic feature `tls` and `tls-roots`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,8 @@ documentation = "https://docs.rs/etcd-client/"
 keywords = ["etcd", "v3", "api", "client", "async"]
 
 [features]
-tls-roots = ["tonic/tls-roots"]
+tls = ["tonic/tls"]
+tls-roots = ["tls", "tonic/tls-roots"]
 
 [dependencies]
 tonic = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,9 @@ homepage = "https://github.com/etcdv3/etcd-client"
 documentation = "https://docs.rs/etcd-client/"
 keywords = ["etcd", "v3", "api", "client", "async"]
 
+[features]
+tls-roots = ["tonic/tls-roots"]
+
 [dependencies]
 tonic = "0.3"
 prost = "0.6"

--- a/src/client.rs
+++ b/src/client.rs
@@ -581,6 +581,8 @@ impl ConnectOptions {
     }
 
     /// Sets TLS options.
+    ///
+    /// Notes that this function have to work with `HTTPS` URLs.
     #[cfg(feature = "tls")]
     #[inline]
     pub fn with_tls(mut self, tls: TlsOptions) -> Self {

--- a/src/client.rs
+++ b/src/client.rs
@@ -31,6 +31,8 @@ use crate::rpc::maintenance::{
     HashResponse, MaintenanceClient, MoveLeaderResponse, SnapshotStreaming, StatusResponse,
 };
 use crate::rpc::watch::{WatchClient, WatchOptions, WatchStream, Watcher};
+#[cfg(feature = "tls")]
+use crate::TlsOptions;
 use tonic::metadata::{Ascii, MetadataValue};
 use tonic::transport::Channel;
 use tonic::Interceptor;
@@ -596,9 +598,6 @@ impl ConnectOptions {
         }
     }
 }
-
-#[cfg(feature = "tls")]
-pub use tonic::transport::{Certificate, ClientTlsConfig as TlsOptions, Identity};
 
 #[cfg(test)]
 mod tests {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,3 +41,5 @@ pub use crate::rpc::watch::{
     Event, EventType, WatchFilterType, WatchOptions, WatchResponse, WatchStream, Watcher,
 };
 pub use crate::rpc::{KeyValue, ResponseHeader};
+#[cfg(feature = "tls")]
+pub use tonic::transport::{Certificate, ClientTlsConfig as TlsOptions, Identity};


### PR DESCRIPTION
Enabling the new feature tls-roots allows connections over HTTPS without any code changes. This only works if the server certificate is issued by one of the standard CAs.