### PR TITLE
Expose more protobuf structs to make transactions testable and mockable

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,8 +109,12 @@ pub use tonic::transport::{Certificate, ClientTlsConfig as TlsOptions, Identity}
 #[cfg(feature = "pub-response-field")]
 #[cfg_attr(docsrs, doc(cfg(feature = "pub-response-field")))]
 pub mod proto {
+    pub use crate::rpc::pb::etcdserverpb::compare::{
+        CompareTarget as PbCompareTarget, TargetUnion as PbTargetUnion,
+    };
     pub use crate::rpc::pb::etcdserverpb::AlarmMember as PbAlarmMember;
     pub use crate::rpc::pb::etcdserverpb::{
+        request_op::Request as PbTxnOpRequest, response_op::Response as PbTxnOpResponse,
         AlarmResponse as PbAlarmResponse, AuthDisableResponse as PbAuthDisableResponse,
         AuthEnableResponse as PbAuthEnableResponse, AuthRoleAddResponse as PbAuthRoleAddResponse,
         AuthRoleDeleteResponse as PbAuthRoleDeleteResponse,
@@ -138,9 +142,10 @@ pub mod proto {
         MemberRemoveResponse as PbMemberRemoveResponse,
         MemberUpdateResponse as PbMemberUpdateResponse, MoveLeaderResponse as PbMoveLeaderResponse,
         PutResponse as PbPutResponse, RangeResponse as PbRangeResponse,
-        ResponseHeader as PbResponseHeader, SnapshotResponse as PbSnapshotResponse,
-        StatusResponse as PbStatusResponse, TxnResponse as PbTxnResponse,
-        WatchResponse as PbWatchResponse,
+        RequestOp as PbTxnRequestOp, ResponseHeader as PbResponseHeader,
+        ResponseOp as PbResponseOp, SnapshotResponse as PbSnapshotResponse,
+        StatusResponse as PbStatusResponse, TxnRequest as PbTxnRequest,
+        TxnResponse as PbTxnResponse, WatchResponse as PbWatchResponse,
     };
     pub use crate::rpc::pb::mvccpb::Event as PbEvent;
     pub use crate::rpc::pb::mvccpb::KeyValue as PbKeyValue;


### PR DESCRIPTION
Hi David,

I already had the feeling that the last PR related to mocking (#23) did not expose everything related to it. It turns out that a few more changes are required in order to test / mock transactions, which are of course crucial for more complex services leveraging `etcd_client`.

This PR enables the following actions by exposing just a few more protobuf structs:
- Convert the `txn` parameter passed to [`etcd_client::KvClient::txn`](https://docs.rs/etcd-client/0.7.2/etcd_client/struct.KvClient.html#method.txn) into a `PbTxnRequest` and check that the right transaction conditions, success, and failure operations are used.
- Construct (and return) nested transaction responses during mocking.

What do you think? Any feedback is highly appreciated. Thanks in advance!