### PR TITLE
Fix: allow KeyValue be exported by feature pub-response-field

### DIFF
--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -68,7 +68,7 @@ impl From<&PbResponseHeader> for &ResponseHeader {
 }
 
 /// Key-value pair.
-#[cfg_attr(feature = "pub-field", visible::StructFields(pub))]
+#[cfg_attr(feature = "pub-response-field", visible::StructFields(pub))]
 #[derive(Debug, Clone)]
 #[repr(transparent)]
 pub struct KeyValue(PbKeyValue);


### PR DESCRIPTION
Signed-off-by: Yu Juncen <yu745514916@live.com>

Fixed #26

A simple demo validating the fix:
```rust
use etcd_client::{Error, KeyValue};

#[derive(Debug)]
struct OwnedKv(Vec<u8>, Vec<u8>);

impl From<KeyValue> for OwnedKv {
    fn from(mut kv: KeyValue) -> Self {
        let key = std::mem::take(&mut kv.0.key);
        let value = std::mem::take(&mut kv.0.value);
        Self(key, value)
    }
}

#[tokio::main]
async fn main() -> Result<(), Error> {
    let mut cli = etcd_client::Client::connect(&["127.0.0.1:2379"], None).await?;
    let mut result = cli.get("hello", None).await?;
    let r = std::mem::take(&mut result.0.kvs);
    println!(
        "{:?}",
        r.into_iter()
            .map::<OwnedKv, _>(|kv| OwnedKv::from(unsafe {
                std::mem::transmute::<_, KeyValue>(kv)
            }))
            .collect::<Vec<_>>()
    );
    Ok(())
}
```

![image](https://user-images.githubusercontent.com/36239017/145668881-54853274-12e6-48aa-a44f-4dc4930461d0.png)
