### PR TITLE
Connect lazy for single endpoint

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -134,7 +134,7 @@ impl Client {
 
         let channel = match endpoints.len() {
             0 => return Err(Error::InvalidArgs(String::from("empty endpoints"))),
-            1 => endpoints[0].connect().await?,
+            1 => endpoints[0].connect_lazy(),
             _ => Channel::balance_list(endpoints.into_iter()),
         };
 


### PR DESCRIPTION
I found `etcd-client` will return err when single endpoint  is temporarily unavailable, but OK and will reconnect for two temporarily unavailable endpoints.
The reason is tonic `Channel::balance_list` internally called  `lazy` [here]( https://github.com/hyperium/tonic/blob/4b0ece6d2854af088fbc1bdb55c2cdd19ec9bb92/tonic/src/transport/service/discover.rs#L45), 

It will be good to connect lazy for single endpoint as well.