### PR TITLE
fix highlight for rustdoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ tokio = { version = "1.0", features = ["full"] }
 
 To get started using `etcd-client`:
 
-```Rust
+```rust
 use etcd_client::{Client, Error};
 
 #[tokio::main]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@
 //!
 //! To get started using `etcd-client`:
 //!
-//! ```Rust
+//! ```rust
 //! use etcd_client::{Client, Error};
 //!
 //! #[tokio::main]


### PR DESCRIPTION
rustdoc doesn't identify "\```Rust" but "```rust" exactly.

.. also in README.md. Although GitHub can properly render "```Rust", keep it consistent.

Signed-off-by: tison <wander4096@gmail.com>

Current:

![image](https://user-images.githubusercontent.com/18818196/150550201-47dd5731-1025-4901-b171-b8146557d520.png)

After:

![image](https://user-images.githubusercontent.com/18818196/150550337-2fbc5741-b86d-469d-97f7-9cd97f870ae9.png)
