### PR TITLE
Dynamically add/remove endpoint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ tokio-stream = "0.1.8"
 tower-service = "0.3.1"
 http = "0.2.6"
 visible =  { version = "0.0.1", optional = true }
+tower = "0.4.12"
 
 [dev-dependencies]
 tokio = { version = "1.17.0", features = ["full"] }

--- a/src/client.rs
+++ b/src/client.rs
@@ -215,7 +215,7 @@ impl Client {
         }
     }
 
-    /// Dynamically add a endpoint to the client.
+    /// Dynamically add an endpoint to the client.
     ///
     /// Which can be used to add a new member to the underlying balance cache.
     /// The typical scenario is that application can use a services discovery
@@ -234,7 +234,7 @@ impl Client {
             .map_err(|e| Error::EndpointError(format!("failed to add endpoint because of {}", e)))
     }
 
-    /// Dynamically remove a endpoint from the client.
+    /// Dynamically remove an endpoint from the client.
     ///
     /// Note that the `endpoint` str should be the same as it was added.
     /// And the underlying balance services cache used the hash from the Uri,

--- a/src/error.rs
+++ b/src/error.rs
@@ -37,6 +37,9 @@ pub enum Error {
 
     /// Invalid header value
     InvalidHeaderValue(http::header::InvalidHeaderValue),
+
+    /// Endpoint error
+    EndpointError(String),
 }
 
 impl Display for Error {
@@ -53,6 +56,7 @@ impl Display for Error {
             Error::LeaseKeepAliveError(e) => write!(f, "lease keep alive error: {}", e),
             Error::ElectError(e) => write!(f, "election error: {}", e),
             Error::InvalidHeaderValue(e) => write!(f, "invalid metadata value: {}", e),
+            Error::EndpointError(e) => write!(f, "endpoint error: {}", e),
         }
     }
 }


### PR DESCRIPTION
Hey, David

In this PR, I expose the inner `Sender` to support endpoint dynamic changes, for applications, without breaking changes.

- `connect_with_balance` the same as the original `connect` except in balance only and saving the `tx` inside the `Client` struct
- `build_endpoints`helper for applications to build `Endpoint`s from str and options
- `is_dynamic`
- `add_endpoint`
- `remove_endpoint`

Maybe in `connect` function, we should save the `tx` if there are more than one endpoint.

In addition, it's better to use `Channel::balance_channel` instead of `Channel::balance_list` which drops the inner `tx`. And `tonic` [may be removed it in the future](https://github.com/hyperium/tonic/pull/939#issuecomment-1069326905). 