### PR TITLE
POC: letting user reuse a single sender/receiver for all watches

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,7 +140,7 @@ pub mod proto {
         PutResponse as PbPutResponse, RangeResponse as PbRangeResponse,
         ResponseHeader as PbResponseHeader, SnapshotResponse as PbSnapshotResponse,
         StatusResponse as PbStatusResponse, TxnResponse as PbTxnResponse,
-        WatchResponse as PbWatchResponse,
+        WatchRequest as PbWatchRequest, WatchResponse as PbWatchResponse,
     };
     pub use crate::rpc::pb::mvccpb::Event as PbEvent;
     pub use crate::rpc::pb::mvccpb::KeyValue as PbKeyValue;


### PR DESCRIPTION
So I'm expecting to have hundreds of watches and I wasn't sure of a good way to manage and poll them all whilst also being able to call the various pieces I need on events.  So I played with this idea of creating an `establish` that does what I need: sets up a bi-directional stream and hands it back to me.  And then I can send the stream back to the `WatchClient` when I want to add more streams and I suppose I can do the same when I want to cancel a specific `watch_id`.  I don't know if this is the best idea, though.  I'm open to suggestions.

