### PR TITLE
Upgrade tonic to 0.9.x and other dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,23 +19,23 @@ tls-roots = ["tls", "tonic/tls-roots"]
 pub-response-field = ["visible"]
 
 [dependencies]
-tonic = "0.9.0"
-prost = "0.11.0"
-tokio = "1.20.1"
-tokio-stream = "0.1.9"
+tonic = "0.9.2"
+prost = "0.11.9"
+tokio = "1.28.0"
+tokio-stream = "0.1.14"
 tower-service = "0.3.2"
-http = "0.2.8"
+http = "0.2.9"
 visible =  { version = "0.0.1", optional = true }
 tower = "0.4.13"
 openssl = { version = "0.10", optional = true }
-hyper = { version = "0.14", features = ["h2", "client"], optional = true }
+hyper = { version = "0.14.26", features = ["h2", "client"], optional = true }
 hyper-openssl = { version = "0.9", optional = true }
 
 [dev-dependencies]
-tokio = { version = "1.20.1", features = ["full"] }
+tokio = { version = "1.28.0", features = ["full"] }
 
 [build-dependencies]
-tonic-build = { version = "0.9.0", default-features = false, features = ["prost"] }
+tonic-build = { version = "0.9.2", default-features = false, features = ["prost"] }
 
 [package.metadata.docs.rs]
 features = ["tls", "tls-roots"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ tls-roots = ["tls", "tonic/tls-roots"]
 pub-response-field = ["visible"]
 
 [dependencies]
-tonic = "0.8.0"
+tonic = "0.9.0"
 prost = "0.11.0"
 tokio = "1.20.1"
 tokio-stream = "0.1.9"
@@ -35,7 +35,7 @@ hyper-openssl = { version = "0.9", optional = true }
 tokio = { version = "1.20.1", features = ["full"] }
 
 [build-dependencies]
-tonic-build = { version = "0.8.0", default-features = false, features = ["prost"] }
+tonic-build = { version = "0.9.0", default-features = false, features = ["prost"] }
 
 [package.metadata.docs.rs]
 features = ["tls", "tls-roots"]

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Notes that we use a fixed `etcd` server URI (localhost:2379) to connect to etcd 
 
 ## Rust version requirements
 
-The minimum supported version is 1.56. The current `etcd-client` version is not guaranteed to build on Rust versions earlier than the minimum supported version.
+The minimum supported version is 1.60. The current `etcd-client` version is not guaranteed to build on Rust versions earlier than the minimum supported version.
 
 ## License
 


### PR DESCRIPTION
Changelog: https://github.com/hyperium/tonic/blob/master/CHANGELOG.md#v090-2023-03-31

Note that this will bump MSRV to 1.60.