### PR TITLE
Upgrade to Rust 2021 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "etcd-client"
 version = "0.11.0"
 authors = ["The etcd-client Authors <davidli2010@foxmail.com>"]
-edition = "2018"
+edition = "2021"
 readme = "README.md"
 license = "MIT"
 description = "An etcd v3 API client"


### PR DESCRIPTION
Turns out `tonic-build` 0.9 generates code that only compiles with 2021 edition.

See also https://github.com/hyperium/tonic/issues/1345