### PR TITLE
Implement take_prev_kvs for DeleteResponse

### DIFF
--- a/src/rpc/kv.rs
+++ b/src/rpc/kv.rs
@@ -568,6 +568,12 @@ impl DeleteResponse {
     pub fn prev_kvs(&self) -> &[KeyValue] {
         unsafe { &*(self.0.prev_kvs.as_slice() as *const _ as *const [KeyValue]) }
     }
+
+    /// If `prev_kv` is set in the request, take the previous key-value pairs, leaving an empty vector in its place.
+    #[inline]
+    pub fn take_prev_kvs(&mut self) -> Vec<KeyValue> {
+        self.0.prev_kvs.drain(..).map(KeyValue::new).collect()
+    }
 }
 
 /// Options for `Compact` operation.

--- a/src/rpc/kv.rs
+++ b/src/rpc/kv.rs
@@ -572,7 +572,7 @@ impl DeleteResponse {
     /// If `prev_kvs` is set in the request, take the previous key-value pairs, leaving an empty vector in its place.
     #[inline]
     pub fn take_prev_kvs(&mut self) -> Vec<KeyValue> {
-        self.0.prev_kvs.drain(..).map(KeyValue::new).collect()
+        unsafe { std::mem::transmute(std::mem::take(&mut self.0.prev_kvs)) }
     }
 }
 

--- a/src/rpc/kv.rs
+++ b/src/rpc/kv.rs
@@ -569,7 +569,7 @@ impl DeleteResponse {
         unsafe { &*(self.0.prev_kvs.as_slice() as *const _ as *const [KeyValue]) }
     }
 
-    /// If `prev_kv` is set in the request, take the previous key-value pairs, leaving an empty vector in its place.
+    /// If `prev_kvs` is set in the request, take the previous key-value pairs, leaving an empty vector in its place.
     #[inline]
     pub fn take_prev_kvs(&mut self) -> Vec<KeyValue> {
         self.0.prev_kvs.drain(..).map(KeyValue::new).collect()


### PR DESCRIPTION
Just like `take_prev_key` for `PutResponse`.

I found this helper function help when HACKING https://github.com/GreptimeTeam/greptimedb/pull/2734.