### PR TITLE
tonic options max_decoding_message_size/max_encoding_message_size

### DIFF
--- a/src/rpc/kv.rs
+++ b/src/rpc/kv.rs
@@ -38,6 +38,22 @@ impl KvClient {
         Self { inner }
     }
 
+    /// Limits the maximum size of a decoded message.
+    ///
+    /// Default: `4MB`
+    pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+        self.inner = self.inner.max_decoding_message_size(limit);
+        self
+    }
+
+    /// Limits the maximum size of an encoded message.
+    ///
+    /// Default: `usize::MAX`
+    pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+        self.inner = self.inner.max_encoding_message_size(limit);
+        self
+    }
+
     /// Puts the given key into the key-value store.
     /// A put request increments the revision of the key-value store
     /// and generates one event in the event history.

--- a/src/rpc/watch.rs
+++ b/src/rpc/watch.rs
@@ -36,6 +36,14 @@ impl WatchClient {
         Self { inner }
     }
 
+    /// Limits the maximum size of a decoded message.
+    ///
+    /// Default: `4MB`
+    pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+        self.inner = self.inner.max_decoding_message_size(limit);
+        self
+    }
+
     /// Watches for events happening or that have happened. Both input and output
     /// are streams; the input stream is for creating and canceling watchers and the output
     /// stream sends events. One watch RPC can watch on multiple key ranges, streaming events


### PR DESCRIPTION
Currently its not possible to define tonic options to change `max_encoding_message_size` and `max_decoding_message_size`
I redefined them in `KvClient` and `WatchClient` (I didn't add `max_encoding_message_size` for watch client as I don't see any use case for it)

```rust
let etcd_client = etcd_client::Client::connect(["localhost:2379"], None).await.unwrap();

let etcd_kv_client = etcd_client
  .kv_client()
  .max_encoding_message_size(10* 1024 * 1024);
  .max_decoding_message_size(10* 1024 * 1024);

let etcd_watch_client = etcd_client
  .watch_client()
  .max_decoding_message_size(10* 1024 * 1024);
```