### PR TITLE
Add GetResponse::take_kvs() & KeyValue::into_key_value()

### DIFF
--- a/src/rpc/kv.rs
+++ b/src/rpc/kv.rs
@@ -453,6 +453,12 @@ impl GetResponse {
         unsafe { &*(self.0.kvs.as_slice() as *const _ as *const [KeyValue]) }
     }
 
+    /// If `kvs` is set in the request, take the key-value pairs, leaving an empty vector in its place.
+    #[inline]
+    pub fn take_kvs(&mut self) -> Vec<KeyValue> {
+        unsafe { std::mem::transmute(std::mem::take(&mut self.0.kvs)) }
+    }
+
     /// Indicates if there are more keys to return in the requested range.
     #[inline]
     pub const fn more(&self) -> bool {

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -126,6 +126,11 @@ impl KeyValue {
         std::str::from_utf8_unchecked(self.value())
     }
 
+    /// Convert to key-value pair.
+    pub fn into_key_value(self) -> (Vec<u8>, Vec<u8>) {
+        (self.0.key, self.0.value)
+    }
+
     /// The revision of last creation on this key.
     #[inline]
     pub const fn create_revision(&self) -> i64 {


### PR DESCRIPTION
cc @davidli2010 I just noticed that `GetResponse#take_kvs` are ignored in my previous PR - it's needed to avoid copy kvs also.