### PR TITLE
Update tonic to 0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ tls-roots = ["tls", "tonic/tls-roots"]
 pub-response-field = ["visible"]
 
 [dependencies]
-tonic = "0.10.0"
+tonic = "0.11.0"
 prost = "0.12.0"
 tokio = "1.32.0"
 tokio-stream = "0.1.14"
@@ -35,7 +35,7 @@ hyper-openssl = { version = "0.9", optional = true }
 tokio = { version = "1.32.0", features = ["full"] }
 
 [build-dependencies]
-tonic-build = { version = "0.10.0", default-features = false, features = ["prost"] }
+tonic-build = { version = "0.11.0", default-features = false, features = ["prost"] }
 
 [package.metadata.docs.rs]
 features = ["tls", "tls-roots"]


### PR DESCRIPTION
This raises the MSRV to 1.70, so probably warrants a minor release, though I don't think `etcd-client` actually specifies an MSRV.