### PR TITLE
Enhance the example which showcases the snapshot maintenance operation.

### DIFF
--- a/examples/maintenance.rs
+++ b/examples/maintenance.rs
@@ -43,6 +43,15 @@ async fn main() -> Result<(), Error> {
             }
         }
     }
+    let resp = msg.message().await?;
+    if let Some(r) = resp {
+        // snapshot hash is sent after r.remaining_bytes() == 0
+        println!(
+            "Received snapshot hash {:?} of len {}",
+            r.blob(),
+            r.blob().len()
+        );
+    }
 
     // Mover leader
     let resp = client.member_list().await?;


### PR DESCRIPTION
The proposed changes make things clearer about the snapshot hash information.

* Snapshot hash is sent after the first occurance of `r.remaining_bytes() == 0`. See https://github.com/etcd-io/etcd/pull/11896 for more information.

* If the snapshot operation is performed as shown in the example previously, restarting the etcd on the stored data from this won't succeed unless etcd is started with `--skip-hash-check=true`. This isn't necessary anymore since the final `msg.message().await` fetches the snapshot hash information.

etcd used: 
```
etcd Version: 3.5.11
Git SHA: 3b252db4f
Go Version: go1.21.5
Go OS/Arch: darwin/arm64
```

etcd-client: `v0.14.0`