### PR TITLE
lease keep alive return lease not found error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ tls-roots = ["tls", "tonic/tls-roots"]
 pub-response-field = ["visible"]
 
 [dependencies]
-tonic = "0.12"
+tonic = "0.12.3"
 prost = "0.13"
 tokio = "1.38"
 tokio-stream = "0.1"
@@ -36,7 +36,7 @@ hyper-util = { version = "0.1", features = ["client-legacy"], optional = true }
 tokio = { version = "1.38", features = ["full"] }
 
 [build-dependencies]
-tonic-build = { version = "0.12", default-features = false, features = ["prost"] }
+tonic-build = { version = "0.12.3", default-features = false, features = ["prost"] }
 
 [package.metadata.docs.rs]
 features = ["tls", "tls-roots"]

--- a/build.rs
+++ b/build.rs
@@ -4,7 +4,7 @@ fn main() {
 
     tonic_build::configure()
         .build_server(false)
-        .compile(
+        .compile_protos(
             &[
                 "proto/auth.proto",
                 "proto/kv.proto",

--- a/examples/lease.rs
+++ b/examples/lease.rs
@@ -40,5 +40,10 @@ async fn main() -> Result<(), Error> {
     // revoke a lease
     let _resp = client.lease_revoke(id).await?;
     println!("revoke a lease with id {:?}", id);
+
+    // keep alive a revoked lease returns error
+    if let Err(err) = client.lease_keep_alive(id).await {
+        println!("revoked lease {:?} keep alive error: {:?}", id, err);
+    }
     Ok(())
 }

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -294,6 +294,9 @@ async fn test_keep_alive() -> Result<()> {
     assert_eq!(resp.ttl(), 60);
 
     client.lease_revoke(id).await?;
+
+    // keep alive a revoked lease should return error
+    assert!(client.lease_keep_alive(id).await.is_err());
     Ok(())
 }
 


### PR DESCRIPTION
Currently [lease_keep_alive](https://github.com/etcdv3/etcd-client/blob/f9110dfc7c6bb2e289535fb717e536a143a6dac0/src/client.rs#L431-L439) returns lease keeper and keep alive stream even when the lease id is not found or revoked, in such case `LeaseKeeper.keep_alive` will not return error and the keep alive stream will yield nothing, so we can't identify that the lease id is invalid.

This patch changes `lease_keep_alive` to return an error when the `lease_id` argument passed has `ttl <= 0` (which means it's expired or revoked, in other words `not found`).

See also https://github.com/etcd-io/etcd/blob/b4450d510ddf0f011c874c28e95175b4bac7f6c8/client/v3/lease.go#L323-L325