### PR TITLE
feat: allow caller to initialize the channel

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ tls-openssl-vendored = ["tls-openssl", "openssl/vendored"]
 tls-roots = ["tls", "tonic/tls-roots"]
 pub-response-field = ["visible"]
 build-server = ["pub-response-field"]
+raw-channel = []
 
 [dependencies]
 tonic = "0.12.3"

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Examples can be found in [`examples`](./examples).
 - `tls-openssl`: Enables the `openssl`-based TLS connections. This would make your binary dynamically link to `libssl`.
 - `tls-openssl-vendored`: Like `tls-openssl`, however compile openssl from source code and statically link to it.
 - `build-server`: Builds a server variant of the etcd protobuf and re-exports it under the same `proto` package as the `pub-response-field` feature does.
+- `raw-channel`: Allows the caller to construct the underlying Tonic channel used by the client.
 
 ## Test
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -41,6 +41,9 @@ pub enum Error {
     /// Endpoint error
     EndpointError(String),
 
+    /// Endpoint set is not managed by this client
+    EndpointsNotManaged,
+
     /// OpenSSL errors.
     #[cfg(feature = "tls-openssl")]
     OpenSsl(openssl::error::ErrorStack),
@@ -61,6 +64,7 @@ impl Display for Error {
             Error::ElectError(e) => write!(f, "election error: {}", e),
             Error::InvalidHeaderValue(e) => write!(f, "invalid metadata value: {}", e),
             Error::EndpointError(e) => write!(f, "endpoint error: {}", e),
+            Error::EndpointsNotManaged => write!(f, "endpoints not managed by this client"),
             #[cfg(feature = "tls-openssl")]
             Error::OpenSsl(e) => write!(f, "open ssl error: {}", e),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,7 @@
 //! - `tls-openssl`: Enables the `openssl`-based TLS connections. This would make your binary dynamically link to `libssl`.
 //! - `tls-openssl-vendored`: Like `tls-openssl`, however compile openssl from source code and statically link to it.
 //! - `build-server`: Builds a server variant of the etcd protobuf and re-exports it under the same `proto` package as the `pub-response-field` feature does.
+//! - `raw-channel`: Allows the caller to construct the underlying Tonic channel used by the client.
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
 


### PR DESCRIPTION
In some scenarios, such as when using a Deterministic Simulation Testing environment such as `turmoil`, when mocking the behaviour of etcd itself, or using non-Tokio sockets for connecting to etcd, it is desirable to construct a Tonic channel externally, then "wrap" it in a `Client` object. This patch enables this use case by creating a `RawClient` type, which is constructed from an existing Tonic channel.

In order to ensure maximum code re-use, the existing `Client` is updated to use the `RawClient` type internally.