### PR TITLE
Use `{RwLock/Mutex}::clear_poison()` to remove `{RwLock/Mutex}::unwrap()`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "etcd-client"
 version = "0.14.1"
 authors = ["The etcd-client Authors <davidli2010@foxmail.com>"]
 edition = "2021"
+rust-version = "1.80.0"
 readme = "README.md"
 license = "MIT OR Apache-2.0"
 description = "An etcd v3 API client"

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Note that we use a fixed `etcd` server URI (localhost:2379) to connect to etcd s
 
 ## Rust version requirements
 
-The minimum supported version is 1.70. The current `etcd-client` version is not guaranteed to build on Rust versions
+The minimum supported version is 1.80. The current `etcd-client` version is not guaranteed to build on Rust versions
 earlier than the minimum supported version.
 
 ## License

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,5 +1,6 @@
 //! Authentication service.
 
+use crate::lock::RwLockExt;
 use http::{header::AUTHORIZATION, HeaderValue, Request};
 use std::sync::{Arc, RwLock};
 use std::task::{Context, Poll};
@@ -33,7 +34,7 @@ where
 
     #[inline]
     fn call(&mut self, mut request: Request<Body>) -> Self::Future {
-        if let Some(token) = self.token.read().unwrap().as_ref() {
+        if let Some(token) = self.token.read_unpoisoned().as_ref() {
             request.headers_mut().insert(AUTHORIZATION, token.clone());
         }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -2,6 +2,7 @@
 
 use crate::channel::Channel;
 use crate::error::{Error, Result};
+use crate::lock::RwLockExt;
 #[cfg(feature = "tls-openssl")]
 use crate::openssl_tls::{self, OpenSslClientConfig, OpenSslConnector};
 use crate::rpc::auth::Permission;
@@ -227,7 +228,7 @@ impl Client {
         if let Some((name, password)) = user {
             let mut tmp_auth = AuthClient::new(channel, auth_token.clone());
             let resp = tmp_auth.authenticate(name, password).await?;
-            auth_token.write().unwrap().replace(resp.token().parse()?);
+            auth_token.write_unpoisoned().replace(resp.token().parse()?);
         }
 
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,7 @@ mod auth;
 mod channel;
 mod client;
 mod error;
+mod lock;
 mod namespace;
 mod openssl_tls;
 mod rpc;

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -1,0 +1,49 @@
+use std::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
+
+#[cfg(feature = "tls-openssl")]
+use std::sync::{Mutex, MutexGuard};
+
+pub trait RwLockExt<T: ?Sized> {
+    fn read_unpoisoned(&self) -> RwLockReadGuard<'_, T>;
+    fn write_unpoisoned(&self) -> RwLockWriteGuard<'_, T>;
+}
+
+impl<T: ?Sized> RwLockExt<T> for RwLock<T> {
+    fn read_unpoisoned(&self) -> RwLockReadGuard<'_, T> {
+        match self.read() {
+            Ok(guard) => guard,
+            Err(e) => {
+                self.clear_poison();
+                e.into_inner()
+            }
+        }
+    }
+
+    fn write_unpoisoned(&self) -> RwLockWriteGuard<'_, T> {
+        match self.write() {
+            Ok(guard) => guard,
+            Err(e) => {
+                self.clear_poison();
+                e.into_inner()
+            }
+        }
+    }
+}
+
+#[cfg(feature = "tls-openssl")]
+pub trait MutexExt<T: ?Sized> {
+    fn lock_unpoisoned(&self) -> MutexGuard<'_, T>;
+}
+
+#[cfg(feature = "tls-openssl")]
+impl<T: ?Sized> MutexExt<T> for Mutex<T> {
+    fn lock_unpoisoned(&self) -> MutexGuard<'_, T> {
+        match self.lock() {
+            Ok(guard) => guard,
+            Err(e) => {
+                self.clear_poison();
+                e.into_inner()
+            }
+        }
+    }
+}

--- a/src/openssl_tls/backoff.rs
+++ b/src/openssl_tls/backoff.rs
@@ -1,3 +1,4 @@
+use crate::lock::MutexExt;
 use std::{
     future::Future,
     pin::Pin,
@@ -85,17 +86,17 @@ impl BackOffStatus {
 
 impl BackOffHandle {
     fn fail(&self) {
-        let mut status = self.inner.lock().unwrap();
+        let mut status = self.inner.lock_unpoisoned();
         status.fail()
     }
 
     fn failed(&self) -> bool {
-        let mut status = self.inner.lock().unwrap();
+        let mut status = self.inner.lock_unpoisoned();
         status.failed()
     }
 
     fn success(&self) {
-        let mut status = self.inner.lock().unwrap();
+        let mut status = self.inner.lock_unpoisoned();
         status.success()
     }
 }


### PR DESCRIPTION
closes #92 