### PR TITLE
feat: add support for requiring a leader

### DIFF
--- a/src/intercept.rs
+++ b/src/intercept.rs
@@ -1,0 +1,33 @@
+use crate::channel::Channel;
+use tonic::{
+    metadata::AsciiMetadataValue,
+    service::{interceptor::InterceptedService, Interceptor as TonicInterceptor},
+};
+
+const REQUIRE_LEADER_KEY: &str = "hasleader";
+const REQUIRE_LEADER_VALUE: &str = "true";
+
+/// An interceptor that conditionally attaches a leader requirement
+/// to the underlying service.
+#[derive(Clone)]
+pub struct Interceptor {
+    pub require_leader: bool,
+}
+
+impl TonicInterceptor for Interceptor {
+    fn call(
+        &mut self,
+        mut request: tonic::Request<()>,
+    ) -> Result<tonic::Request<()>, tonic::Status> {
+        if self.require_leader {
+            request.metadata_mut().append(
+                REQUIRE_LEADER_KEY,
+                AsciiMetadataValue::from_static(REQUIRE_LEADER_VALUE),
+            );
+        }
+        Ok(request)
+    }
+}
+
+/// A type alias to make using this interceptor easier.
+pub type InterceptedChannel = InterceptedService<Channel, Interceptor>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,7 @@ mod auth;
 mod channel;
 mod client;
 mod error;
+mod intercept;
 mod lock;
 mod namespace;
 mod openssl_tls;

--- a/src/rpc/auth.rs
+++ b/src/rpc/auth.rs
@@ -3,8 +3,8 @@
 pub use crate::rpc::pb::authpb::permission::Type as PermissionType;
 
 use crate::auth::AuthService;
-use crate::channel::Channel;
 use crate::error::Result;
+use crate::intercept::InterceptedChannel;
 use crate::lock::RwLockExt;
 use crate::rpc::pb::authpb::{Permission as PbPermission, UserAddOptions as PbUserAddOptions};
 use crate::rpc::pb::etcdserverpb::auth_client::AuthClient as PbAuthClient;
@@ -43,14 +43,17 @@ use tonic::{IntoRequest, Request};
 /// Client for Auth operations.
 #[derive(Clone)]
 pub struct AuthClient {
-    inner: PbAuthClient<AuthService<Channel>>,
+    inner: PbAuthClient<AuthService<InterceptedChannel>>,
     auth_token: Arc<RwLock<Option<HeaderValue>>>,
 }
 
 impl AuthClient {
     /// Creates an auth client.
     #[inline]
-    pub(crate) fn new(channel: Channel, auth_token: Arc<RwLock<Option<HeaderValue>>>) -> Self {
+    pub(crate) fn new(
+        channel: InterceptedChannel,
+        auth_token: Arc<RwLock<Option<HeaderValue>>>,
+    ) -> Self {
         let inner = PbAuthClient::new(AuthService::new(channel, auth_token.clone()));
         Self { inner, auth_token }
     }

--- a/src/rpc/cluster.rs
+++ b/src/rpc/cluster.rs
@@ -1,8 +1,8 @@
 //! Etcd Cluster RPC.
 
 use crate::auth::AuthService;
-use crate::channel::Channel;
 use crate::error::Result;
+use crate::intercept::InterceptedChannel;
 use crate::rpc::pb::etcdserverpb::cluster_client::ClusterClient as PbClusterClient;
 use crate::rpc::pb::etcdserverpb::{
     Member as PbMember, MemberAddRequest as PbMemberAddRequest,
@@ -22,13 +22,16 @@ use tonic::{IntoRequest, Request};
 #[repr(transparent)]
 #[derive(Clone)]
 pub struct ClusterClient {
-    inner: PbClusterClient<AuthService<Channel>>,
+    inner: PbClusterClient<AuthService<InterceptedChannel>>,
 }
 
 impl ClusterClient {
     /// Creates an Cluster client.
     #[inline]
-    pub(crate) fn new(channel: Channel, auth_token: Arc<RwLock<Option<HeaderValue>>>) -> Self {
+    pub(crate) fn new(
+        channel: InterceptedChannel,
+        auth_token: Arc<RwLock<Option<HeaderValue>>>,
+    ) -> Self {
         let inner = PbClusterClient::new(AuthService::new(channel, auth_token));
         Self { inner }
     }

--- a/src/rpc/election.rs
+++ b/src/rpc/election.rs
@@ -1,8 +1,8 @@
 //! Etcd Election RPC.
 
 use crate::auth::AuthService;
-use crate::channel::Channel;
 use crate::error::Result;
+use crate::intercept::InterceptedChannel;
 use crate::rpc::pb::v3electionpb::election_client::ElectionClient as PbElectionClient;
 use crate::rpc::pb::v3electionpb::{
     CampaignRequest as PbCampaignRequest, CampaignResponse as PbCampaignResponse,
@@ -22,7 +22,7 @@ use tonic::{IntoRequest, Request, Streaming};
 #[repr(transparent)]
 #[derive(Clone)]
 pub struct ElectionClient {
-    inner: PbElectionClient<AuthService<Channel>>,
+    inner: PbElectionClient<AuthService<InterceptedChannel>>,
 }
 
 /// Options for `campaign` operation.
@@ -487,7 +487,10 @@ impl From<&PbLeaderKey> for &LeaderKey {
 impl ElectionClient {
     /// Creates a election
     #[inline]
-    pub(crate) fn new(channel: Channel, auth_token: Arc<RwLock<Option<HeaderValue>>>) -> Self {
+    pub(crate) fn new(
+        channel: InterceptedChannel,
+        auth_token: Arc<RwLock<Option<HeaderValue>>>,
+    ) -> Self {
         let inner = PbElectionClient::new(AuthService::new(channel, auth_token));
         Self { inner }
     }

--- a/src/rpc/kv.rs
+++ b/src/rpc/kv.rs
@@ -4,8 +4,8 @@ pub use crate::rpc::pb::etcdserverpb::compare::CompareResult as CompareOp;
 pub use crate::rpc::pb::etcdserverpb::range_request::{SortOrder, SortTarget};
 
 use crate::auth::AuthService;
-use crate::channel::Channel;
 use crate::error::Result;
+use crate::intercept::InterceptedChannel;
 use crate::rpc::pb::etcdserverpb::compare::{CompareTarget, TargetUnion};
 use crate::rpc::pb::etcdserverpb::kv_client::KvClient as PbKvClient;
 use crate::rpc::pb::etcdserverpb::request_op::Request as PbTxnOp;
@@ -29,13 +29,16 @@ use tonic::{IntoRequest, Request};
 #[repr(transparent)]
 #[derive(Clone)]
 pub struct KvClient {
-    inner: PbKvClient<AuthService<Channel>>,
+    inner: PbKvClient<AuthService<InterceptedChannel>>,
 }
 
 impl KvClient {
     /// Creates a kv client.
     #[inline]
-    pub(crate) fn new(channel: Channel, auth_token: Arc<RwLock<Option<HeaderValue>>>) -> Self {
+    pub(crate) fn new(
+        channel: InterceptedChannel,
+        auth_token: Arc<RwLock<Option<HeaderValue>>>,
+    ) -> Self {
         let inner = PbKvClient::new(AuthService::new(channel, auth_token));
         Self { inner }
     }

--- a/src/rpc/lease.rs
+++ b/src/rpc/lease.rs
@@ -1,8 +1,8 @@
 //! Etcd Lease RPC.
 
 use crate::auth::AuthService;
-use crate::channel::Channel;
 use crate::error::Result;
+use crate::intercept::InterceptedChannel;
 use crate::rpc::pb::etcdserverpb::lease_client::LeaseClient as PbLeaseClient;
 use crate::rpc::pb::etcdserverpb::{
     LeaseGrantRequest as PbLeaseGrantRequest, LeaseGrantResponse as PbLeaseGrantResponse,
@@ -29,13 +29,16 @@ use tonic::{IntoRequest, Request, Streaming};
 #[repr(transparent)]
 #[derive(Clone)]
 pub struct LeaseClient {
-    inner: PbLeaseClient<AuthService<Channel>>,
+    inner: PbLeaseClient<AuthService<InterceptedChannel>>,
 }
 
 impl LeaseClient {
     /// Creates a `LeaseClient`.
     #[inline]
-    pub(crate) fn new(channel: Channel, auth_token: Arc<RwLock<Option<HeaderValue>>>) -> Self {
+    pub(crate) fn new(
+        channel: InterceptedChannel,
+        auth_token: Arc<RwLock<Option<HeaderValue>>>,
+    ) -> Self {
         let inner = PbLeaseClient::new(AuthService::new(channel, auth_token));
         Self { inner }
     }

--- a/src/rpc/lock.rs
+++ b/src/rpc/lock.rs
@@ -2,8 +2,8 @@
 
 use super::pb::v3lockpb;
 use crate::auth::AuthService;
-use crate::channel::Channel;
 use crate::error::Result;
+use crate::intercept::InterceptedChannel;
 use crate::rpc::ResponseHeader;
 use http::HeaderValue;
 use std::sync::{Arc, RwLock};
@@ -18,13 +18,16 @@ use v3lockpb::{
 #[repr(transparent)]
 #[derive(Clone)]
 pub struct LockClient {
-    inner: PbLockClient<AuthService<Channel>>,
+    inner: PbLockClient<AuthService<InterceptedChannel>>,
 }
 
 impl LockClient {
     /// Creates a lock client.
     #[inline]
-    pub(crate) fn new(channel: Channel, auth_token: Arc<RwLock<Option<HeaderValue>>>) -> Self {
+    pub(crate) fn new(
+        channel: InterceptedChannel,
+        auth_token: Arc<RwLock<Option<HeaderValue>>>,
+    ) -> Self {
         let inner = PbLockClient::new(AuthService::new(channel, auth_token));
         Self { inner }
     }

--- a/src/rpc/maintenance.rs
+++ b/src/rpc/maintenance.rs
@@ -5,8 +5,8 @@ pub use crate::rpc::pb::etcdserverpb::AlarmType;
 
 use super::pb::etcdserverpb;
 use crate::auth::AuthService;
-use crate::channel::Channel;
 use crate::error::Result;
+use crate::intercept::InterceptedChannel;
 use crate::rpc::pb::etcdserverpb::{
     AlarmRequest as PbAlarmRequest, AlarmResponse as PbAlarmResponse,
     DefragmentRequest as PbDefragmentRequest, DefragmentResponse as PbDefragmentResponse,
@@ -28,7 +28,7 @@ use tonic::{IntoRequest, Request};
 #[repr(transparent)]
 #[derive(Clone)]
 pub struct MaintenanceClient {
-    inner: PbMaintenanceClient<AuthService<Channel>>,
+    inner: PbMaintenanceClient<AuthService<InterceptedChannel>>,
 }
 
 /// Options for `alarm` operation.
@@ -556,7 +556,10 @@ impl MoveLeaderResponse {
 impl MaintenanceClient {
     /// Creates a maintenance client.
     #[inline]
-    pub(crate) fn new(channel: Channel, auth_token: Arc<RwLock<Option<HeaderValue>>>) -> Self {
+    pub(crate) fn new(
+        channel: InterceptedChannel,
+        auth_token: Arc<RwLock<Option<HeaderValue>>>,
+    ) -> Self {
         let inner = PbMaintenanceClient::new(AuthService::new(channel, auth_token));
         Self { inner }
     }

--- a/src/rpc/watch.rs
+++ b/src/rpc/watch.rs
@@ -3,8 +3,8 @@
 pub use crate::rpc::pb::mvccpb::event::EventType;
 
 use crate::auth::AuthService;
-use crate::channel::Channel;
 use crate::error::{Error, Result};
+use crate::intercept::InterceptedChannel;
 use crate::rpc::pb::etcdserverpb::watch_client::WatchClient as PbWatchClient;
 use crate::rpc::pb::etcdserverpb::watch_request::RequestUnion as WatchRequestUnion;
 use crate::rpc::pb::etcdserverpb::{
@@ -25,13 +25,16 @@ use tonic::Streaming;
 #[repr(transparent)]
 #[derive(Clone)]
 pub struct WatchClient {
-    inner: PbWatchClient<AuthService<Channel>>,
+    inner: PbWatchClient<AuthService<InterceptedChannel>>,
 }
 
 impl WatchClient {
     /// Creates a watch client.
     #[inline]
-    pub(crate) fn new(channel: Channel, auth_token: Arc<RwLock<Option<HeaderValue>>>) -> Self {
+    pub(crate) fn new(
+        channel: InterceptedChannel,
+        auth_token: Arc<RwLock<Option<HeaderValue>>>,
+    ) -> Self {
         let inner = PbWatchClient::new(AuthService::new(channel, auth_token));
         Self { inner }
     }

--- a/tests/testing.rs
+++ b/tests/testing.rs
@@ -6,5 +6,8 @@ pub type Result<T> = std::result::Result<T, Error>;
 
 /// Get client for testing.
 pub async fn get_client() -> Result<Client> {
-    Client::connect([DEFAULT_TEST_ENDPOINT], None).await
+    // Require a leader be present -- with only a single node, this
+    // should never fail.
+    let options = etcd_client::ConnectOptions::new().with_require_leader(true);
+    Client::connect([DEFAULT_TEST_ENDPOINT], Some(options)).await
 }


### PR DESCRIPTION
Some etcd functions require a leader to be present in the partition that the client is connected to. As per Raft, it is useful for a client to be able to guarantee the presence of a leader on each request, as this is a method for detecting if the client is connected to the majority partition.

As per the Golang implementation of the etcdv3 client, this functionality is exposed through the use of gRPC custom metadata, which is supported in Tonic through the Interceptors system. This patch adds a connection option that allows the client to enforce the presence of a leader, and implements it through the use of an interceptor that attaches the metadata parameter to the gRPC client.