### PR TITLE
feat(ci): run cargo clippy with all feature combinations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,12 +18,14 @@ jobs:
       - run: sudo apt install -y protobuf-compiler libprotobuf-dev
       - name: Check out repository code
         uses: actions/checkout@v4
+      - name: install cargo-hack
+        uses: taiki-e/install-action@cargo-hack
       - run: cargo --version --verbose
       - run: rustc --version --verbose
       - name: format check
         run: cargo fmt --check
       - name: clippy
-        run: cargo clippy --all-targets -- -D warnings
+        run: cargo hack --feature-powerset --mutually-exclusive-features tls,tls-openssl --mutually-exclusive-features tls-roots,tls-openssl clippy --all-targets -- -D warnings
       - name: unit test
         run: cargo test
       - run: cargo run --example kv

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,5 +1,6 @@
 //! Asynchronous client & synchronous client.
 
+#[cfg(not(feature = "tls-openssl"))]
 use crate::channel::Channel;
 use crate::error::{Error, Result};
 use crate::intercept::{InterceptedChannel, Interceptor};


### PR DESCRIPTION
Currently, in the GitHub Actions CI, only the default features are actually run through `cargo clippy`. This patch adds support for testing all _combinations_ of features via `cargo-hack`, excluding the mutually-exclusive `tls` and `tls-openssl` features.

This change is not intended to be a comprehensive validation of all combinations of features, but instead a check to verify all code actually compiles with all combinations of features. It can, however, be extended to support running tests with all combinations. That will be rather complex, given the need to create a TLS cert chain to comprehensively test TLS support, so that task was not done here.

This CI change caught a case where the existing code produces a warning when compiling with `tls-openssl` enabled. This patch also fixes that with a `#[cfg]` attribute.