### PR TITLE
build(deps): upgrade tonic from 0.12 to 0.13.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,12 @@ jobs:
       - name: format check
         run: cargo fmt --check
       - name: clippy
-        run: cargo hack --feature-powerset --mutually-exclusive-features tls,tls-openssl --mutually-exclusive-features tls-roots,tls-openssl clippy --all-targets -- -D warnings
+        run: |
+          cargo hack --feature-powerset \
+          --exclude-features _rust-tls \
+          --mutually-exclusive-features tls,tls-ring,tls-aws-lc,tls-openssl \
+          --mutually-exclusive-features tls-roots,tls-openssl \
+          clippy --all-targets -- -D warnings
       - name: unit test
         run: cargo test
       - run: cargo run --example kv

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,22 +13,22 @@ documentation = "https://docs.rs/etcd-client/"
 keywords = ["etcd", "v3", "api", "client", "async"]
 
 [features]
-tls = ["tonic/tls"]
+tls = ["tonic/tls-ring"]
 tls-openssl = ["openssl", "hyper-openssl", "hyper", "hyper-util"]
 tls-openssl-vendored = ["tls-openssl", "openssl/vendored"]
-tls-roots = ["tls", "tonic/tls-roots"]
+tls-roots = ["tls", "tonic/tls-native-roots"]
 pub-response-field = ["visible"]
 build-server = ["pub-response-field"]
 
 [dependencies]
-tonic = "0.12.3"
+tonic = "0.13"
 prost = "0.13"
 tokio = "1.38"
 tokio-stream = "0.1"
 tower-service = "0.3"
 http = "1.1"
 visible = { version = "0.0.1", optional = true }
-tower = { version = "0.4", default-features = false }
+tower = { version = "0.5", default-features = false }
 openssl = { version = "0.10", optional = true }
 hyper = { version = "1.4", features = ["client"], optional = true }
 hyper-openssl = { version = "0.10", features = ["client-legacy", "tokio"], optional = true }
@@ -38,7 +38,7 @@ hyper-util = { version = "0.1", features = ["client-legacy"], optional = true }
 tokio = { version = "1.38", features = ["full"] }
 
 [build-dependencies]
-tonic-build = { version = "0.12.3", default-features = false, features = ["prost"] }
+tonic-build = { version = "0.13", default-features = false, features = ["prost"] }
 
 [package.metadata.docs.rs]
 features = ["tls", "tls-roots"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,10 @@ documentation = "https://docs.rs/etcd-client/"
 keywords = ["etcd", "v3", "api", "client", "async"]
 
 [features]
-tls = ["tonic/tls-ring"]
+_tls-rustls = [] # Internal feature.
+tls = ["_tls-rustls", "tonic/tls-ring"]
+tls-aws-lc = ["_tls-rustls", "tonic/tls-aws-lc"]
+tls-ring = ["_tls-rustls", "tonic/tls-ring"]
 tls-openssl = ["openssl", "hyper-openssl", "hyper", "hyper-util", "futures"]
 tls-openssl-vendored = ["tls-openssl", "openssl/vendored"]
 tls-roots = ["tls", "tonic/tls-native-roots"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["etcd", "v3", "api", "client", "async"]
 
 [features]
 tls = ["tonic/tls-ring"]
-tls-openssl = ["openssl", "hyper-openssl", "hyper", "hyper-util"]
+tls-openssl = ["openssl", "hyper-openssl", "hyper", "hyper-util", "futures"]
 tls-openssl-vendored = ["tls-openssl", "openssl/vendored"]
 tls-roots = ["tls", "tonic/tls-native-roots"]
 pub-response-field = ["visible"]
@@ -33,6 +33,7 @@ openssl = { version = "0.10", optional = true }
 hyper = { version = "1.4", features = ["client"], optional = true }
 hyper-openssl = { version = "0.10", features = ["client-legacy", "tokio"], optional = true }
 hyper-util = { version = "0.1", features = ["client-legacy"], optional = true }
+futures = { version = "0.3", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1.38", features = ["full"] }

--- a/src/client.rs
+++ b/src/client.rs
@@ -39,7 +39,7 @@ use crate::rpc::maintenance::{
 use crate::rpc::watch::{WatchClient, WatchOptions, WatchStream, Watcher};
 #[cfg(feature = "tls-openssl")]
 use crate::OpenSslResult;
-#[cfg(feature = "tls")]
+#[cfg(feature = "_tls-rustls")]
 use crate::TlsOptions;
 use http::uri::Uri;
 use http::HeaderValue;
@@ -130,7 +130,7 @@ impl Client {
         #[cfg(feature = "tls-openssl")]
         use tonic::transport::Channel;
         let mut endpoint = if url.starts_with(HTTP_PREFIX) {
-            #[cfg(feature = "tls")]
+            #[cfg(feature = "_tls-rustls")]
             if let Some(connect_options) = options {
                 if connect_options.tls.is_some() {
                     return Err(Error::InvalidArgs(String::from(
@@ -141,17 +141,17 @@ impl Client {
 
             Channel::builder(url.parse()?)
         } else if url.starts_with(HTTPS_PREFIX) {
-            #[cfg(not(any(feature = "tls", feature = "tls-openssl")))]
+            #[cfg(not(any(feature = "_tls-rustls", feature = "tls-openssl")))]
             return Err(Error::InvalidArgs(String::from(
                 "HTTPS URLs are only supported with the feature \"tls\"",
             )));
 
-            #[cfg(all(feature = "tls-openssl", not(feature = "tls")))]
+            #[cfg(all(feature = "tls-openssl", not(feature = "_tls-rustls")))]
             {
                 Channel::builder(url.parse()?)
             }
 
-            #[cfg(feature = "tls")]
+            #[cfg(feature = "_tls-rustls")]
             {
                 let tls = if let Some(connect_options) = options {
                     connect_options.tls.clone()
@@ -163,7 +163,7 @@ impl Client {
                 Channel::builder(url.parse()?).tls_config(tls)?
             }
         } else {
-            #[cfg(feature = "tls")]
+            #[cfg(feature = "_tls-rustls")]
             {
                 let tls = if let Some(connect_options) = options {
                     connect_options.tls.clone()
@@ -183,7 +183,7 @@ impl Client {
                 }
             }
 
-            #[cfg(all(feature = "tls-openssl", not(feature = "tls")))]
+            #[cfg(all(feature = "tls-openssl", not(feature = "_tls-rustls")))]
             {
                 let pfx = if options.as_ref().and_then(|o| o.otls.as_ref()).is_some() {
                     HTTPS_PREFIX
@@ -194,7 +194,7 @@ impl Client {
                 Channel::builder(e.parse()?)
             }
 
-            #[cfg(all(not(feature = "tls"), not(feature = "tls-openssl")))]
+            #[cfg(all(not(feature = "_tls-rustls"), not(feature = "tls-openssl")))]
             {
                 let e = HTTP_PREFIX.to_owned() + url;
                 Channel::builder(e.parse()?)
@@ -776,7 +776,7 @@ pub struct ConnectOptions {
     connect_timeout: Option<Duration>,
     /// TCP keepalive.
     tcp_keepalive: Option<Duration>,
-    #[cfg(feature = "tls")]
+    #[cfg(feature = "_tls-rustls")]
     tls: Option<TlsOptions>,
     #[cfg(feature = "tls-openssl")]
     otls: Option<OpenSslResult<OpenSslConnector>>,
@@ -795,8 +795,8 @@ impl ConnectOptions {
     /// Sets TLS options.
     ///
     /// Notes that this function have to work with `HTTPS` URLs.
-    #[cfg_attr(docsrs, doc(cfg(feature = "tls")))]
-    #[cfg(feature = "tls")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "_tls-rustls")))]
+    #[cfg(feature = "_tls-rustls")]
     #[inline]
     pub fn with_tls(mut self, tls: TlsOptions) -> Self {
         self.tls = Some(tls);
@@ -872,7 +872,7 @@ impl ConnectOptions {
             timeout: None,
             connect_timeout: None,
             tcp_keepalive: None,
-            #[cfg(feature = "tls")]
+            #[cfg(feature = "_tls-rustls")]
             tls: None,
             #[cfg(feature = "tls-openssl")]
             otls: None,

--- a/src/client.rs
+++ b/src/client.rs
@@ -70,9 +70,6 @@ pub struct Client {
     cluster: ClusterClient,
     election: ElectionClient,
     options: Option<ConnectOptions>,
-    #[cfg(not(feature = "tls-openssl"))]
-    tx: Sender<Change<Uri, Endpoint>>,
-    #[cfg(feature = "tls-openssl")]
     tx: Sender<Change<Uri, Endpoint>>,
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -43,6 +43,7 @@ use crate::OpenSslResult;
 use crate::TlsOptions;
 use http::uri::Uri;
 use http::HeaderValue;
+use tonic::transport::channel::Change;
 
 use std::str::FromStr;
 use std::sync::{Arc, RwLock};
@@ -50,8 +51,6 @@ use std::time::Duration;
 use tokio::sync::mpsc::Sender;
 
 use tonic::transport::Endpoint;
-
-use tower::discover::Change;
 
 const HTTP_PREFIX: &str = "http://";
 const HTTPS_PREFIX: &str = "https://";

--- a/src/client.rs
+++ b/src/client.rs
@@ -43,7 +43,10 @@ use crate::OpenSslResult;
 use crate::TlsOptions;
 use http::uri::Uri;
 use http::HeaderValue;
+#[cfg(not(feature = "tls-openssl"))]
 use tonic::transport::channel::Change;
+#[cfg(feature = "tls-openssl")]
+use tower::discover::Change;
 
 use std::str::FromStr;
 use std::sync::{Arc, RwLock};
@@ -67,6 +70,9 @@ pub struct Client {
     cluster: ClusterClient,
     election: ElectionClient,
     options: Option<ConnectOptions>,
+    #[cfg(not(feature = "tls-openssl"))]
+    tx: Sender<Change<Uri, Endpoint>>,
+    #[cfg(feature = "tls-openssl")]
     tx: Sender<Change<Uri, Endpoint>>,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,8 +109,8 @@ pub use crate::rpc::watch::{
 };
 pub use crate::rpc::{KeyValue, ResponseHeader};
 
-#[cfg(feature = "tls")]
-#[cfg_attr(docsrs, doc(cfg(feature = "tls")))]
+#[cfg(feature = "_tls-rustls")]
+#[cfg_attr(docsrs, doc(cfg(feature = "_tls-rustls")))]
 pub use tonic::transport::{Certificate, ClientTlsConfig as TlsOptions, Identity};
 
 #[cfg(feature = "tls-openssl")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,9 @@
 //!
 //! # Feature Flags
 //!
-//! - `tls`: Enables the `rustls`-based TLS connection. Not enabled by default.
+//! - `tls`: Enables the `rustls`-based TLS connection, crypto provider is `ring`. Not enabled by default.
+//! - `tls-aws-lc`: Enables the `rustls`-based TLS connection, crypto provider is `aws-lc`. Not enabled by default.
+//! - `tls-ring`: Enables the `rustls`-based TLS connection, crypto provider is `ring`. Not enabled by default.
 //! - `tls-roots`: Adds system trust roots to `rustls`-based TLS connection using the `rustls-native-certs` crate. Not enabled by default.
 //! - `pub-response-field`: Exposes structs used to create regular `etcd-client` responses including internal protobuf representations. Useful for mocking. Not enabled by default.
 //! - `tls-openssl`: Enables the `openssl`-based TLS connections. This would make your binary dynamically link to `libssl`.

--- a/src/openssl_tls/transport.rs
+++ b/src/openssl_tls/transport.rs
@@ -47,7 +47,7 @@ impl OpenSslConnector {
     }
 }
 
-#[cfg(feature = "tls")]
+#[cfg(feature = "_tls-rustls")]
 compile_error!(concat!(
     "**You should only enable one of `tls` and `tls-openssl`.** Reason: ",
     "For now, `tls-openssl` would take over the transport layer (sockets) to implement TLS based connection. ",

--- a/src/openssl_tls/transport.rs
+++ b/src/openssl_tls/transport.rs
@@ -1,6 +1,7 @@
-use std::time::Duration;
+use std::{error::Error, time::Duration};
 
-use super::backoff::{BackOffStatus, BackOffWhenFail};
+use super::backoff::{BackOffStatus, BackOffWhenFail, TraceFailFuture};
+use futures::future::MapErr;
 use http::{Request, Uri};
 use hyper_openssl::client::legacy::HttpsConnector;
 use hyper_util::client::legacy::connect::HttpConnector;
@@ -13,8 +14,8 @@ use openssl::{
 use tokio::sync::mpsc::{Receiver, Sender};
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::{
-    body::BoxBody,
-    transport::{Channel, Endpoint},
+    body::Body,
+    transport::{channel::ResponseFuture, Channel, Endpoint, Error as TonicError},
 };
 use tower::{balance::p2c::Balance, buffer::Buffer, discover::Change};
 
@@ -23,12 +24,11 @@ use crate::error::Result;
 pub type SslConnectorBuilder = openssl::ssl::SslConnectorBuilder;
 pub type OpenSslResult<T> = std::result::Result<T, ErrorStack>;
 // Below are some type alias for make clearer types.
-pub type TonicRequest = Request<BoxBody>;
-pub type Buffered<T> = Buffer<T, TonicRequest>;
-pub type Balanced<T> = Balance<T, TonicRequest>;
-pub type OpenSslChannel = Buffered<Balanced<OpenSslDiscover<Uri>>>;
-/// OpenSslDiscover is the backend for balanced channel based on OpenSSL transports.
-/// Because `Channel::balance` doesn't allow us to provide custom connector, we must implement ourselves' balancer...
+pub type TonicRequest = Request<Body>;
+pub type Buffered<T> = Buffer<TonicRequest, T>;
+pub type OpenSslChannel = Buffered<
+    MapErr<TraceFailFuture<ResponseFuture>, fn(TonicError) -> Box<dyn Error + Send + Sync>>,
+>;
 pub type OpenSslDiscover<K> = ReceiverStream<Result<Change<K, BackOffWhenFail<Channel>>>>;
 
 #[derive(Clone)]


### PR DESCRIPTION
Hi, this pr mainly upgrade some dependencies, include tonic, tower, tonic-build.

Note: In this PR, we choose to use `ring` crypto provider in `tls` feature. And we add two additional features: `tls-ring`, `tls-aws-lc`.
