### PR TITLE
feat: add the ability to build a server

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ tls-openssl = ["openssl", "hyper-openssl", "hyper", "hyper-util"]
 tls-openssl-vendored = ["tls-openssl", "openssl/vendored"]
 tls-roots = ["tls", "tonic/tls-roots"]
 pub-response-field = ["visible"]
+build-server = ["pub-response-field"]
 
 [dependencies]
 tonic = "0.12.3"

--- a/build.rs
+++ b/build.rs
@@ -1,9 +1,19 @@
+#[cfg(feature = "build-server")]
+fn should_build_server() -> bool {
+    true
+}
+
+#[cfg(not(feature = "build-server"))]
+fn should_build_server() -> bool {
+    false
+}
+
 fn main() {
     let proto_root = "proto";
     println!("cargo:rerun-if-changed={}", proto_root);
 
     tonic_build::configure()
-        .build_server(false)
+        .build_server(should_build_server())
         .compile_protos(
             &[
                 "proto/auth.proto",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,4 +161,46 @@ pub mod proto {
     pub use crate::rpc::pb::v3lockpb::{
         LockResponse as PbLockResponse, UnlockResponse as PbUnlockResponse,
     };
+
+    #[cfg(feature = "build-server")]
+    pub use crate::rpc::pb::etcdserverpb::{
+        auth_server::{Auth as PbAuthService, AuthServer as PbAuthServer},
+        cluster_server::{Cluster as PbClusterService, ClusterServer as PbClusterServer},
+        kv_server::{Kv as PbKvService, KvServer as PbKvServer},
+        lease_server::{Lease as PbLeaseService, LeaseServer as PbLeaseServer},
+        maintenance_server::{
+            Maintenance as PbMaintenanceService, MaintenanceServer as PbMaintenanceServer,
+        },
+        watch_server::{Watch as PbWatchService, WatchServer as PbWatchServer},
+    };
+
+    #[cfg(feature = "build-server")]
+    pub use crate::rpc::pb::etcdserverpb::{
+        AlarmRequest as PbAlarmRequest, AuthDisableRequest as PbAuthDisableRequest,
+        AuthEnableRequest as PbAuthEnableRequest, AuthRoleAddRequest as PbAuthRoleAddRequest,
+        AuthRoleDeleteRequest as PbAuthRoleDeleteRequest,
+        AuthRoleGetRequest as PbAuthRoleGetRequest,
+        AuthRoleGrantPermissionRequest as PbAuthRoleGrantPermissionRequest,
+        AuthRoleListRequest as PbAuthRoleListRequest,
+        AuthRoleRevokePermissionRequest as PbAuthRoleRevokePermissionRequest,
+        AuthUserAddRequest as PbAuthUserAddRequest,
+        AuthUserChangePasswordRequest as PbAuthUserChangePasswordRequest,
+        AuthUserDeleteRequest as PbAuthUserDeleteRequest,
+        AuthUserGetRequest as PbAuthUserGetRequest,
+        AuthUserGrantRoleRequest as PbAuthUserGrantRoleRequest,
+        AuthUserListRequest as PbAuthUserListRequest,
+        AuthUserRevokeRoleRequest as PbAuthUserRevokeRoleRequest,
+        AuthenticateRequest as PbAuthenticateRequest, CompactionRequest as PbCompactionRequest,
+        DefragmentRequest as PbDefragmentRequest, DeleteRangeRequest as PbDeleteRequest,
+        HashKvRequest as PbHashKvRequest, HashRequest as PbHashRequest,
+        LeaseGrantRequest as PbLeaseGrantRequest, LeaseKeepAliveRequest as PbLeaseKeepAliveRequest,
+        LeaseLeasesRequest as PbLeaseLeasesRequest, LeaseRevokeRequest as PbLeaseRevokeRequest,
+        LeaseTimeToLiveRequest as PbLeaseTimeToLiveRequest, MemberAddRequest as PbMemberAddRequest,
+        MemberListRequest as PbMemberListRequest, MemberPromoteRequest as PbMemberPromoteRequest,
+        MemberRemoveRequest as PbMemberRemoveRequest, MemberUpdateRequest as PbMemberUpdateRequest,
+        MoveLeaderRequest as PbMoveLeaderRequest, PutRequest as PbPutRequest,
+        RangeRequest as PbRangeRequest, SnapshotRequest as PbSnapshotRequest,
+        StatusRequest as PbStatusRequest, TxnRequest as PbTxnRequest,
+        WatchRequest as PbWatchRequest,
+    };
 }


### PR DESCRIPTION
In order to support Determinstic Simulation Testing (DST) via the `turmoil` crate, this patch introduces a new feature flag, `build-server`, which builds a server variant of the etcd protobuf and re-exports it under the same `proto` package as the `pub-response-field` feature flag does. This enables a downstream user to implement various mock etcd scenarios within a Turmoil environment, allowing for more precise testing.