### PR TITLE
build(deps): upgrade tonic from 0.12 to 0.13.x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,32 +13,34 @@ documentation = "https://docs.rs/etcd-client/"
 keywords = ["etcd", "v3", "api", "client", "async"]
 
 [features]
-tls = ["tonic/tls"]
-tls-openssl = ["openssl", "hyper-openssl", "hyper", "hyper-util"]
+tls = ["tonic/tls-ring"]
+tls-openssl = ["openssl", "hyper-openssl", "hyper", "hyper-util", "futures"]
 tls-openssl-vendored = ["tls-openssl", "openssl/vendored"]
-tls-roots = ["tls", "tonic/tls-roots"]
+tls-roots = ["tls", "tonic/tls-native-roots"]
 pub-response-field = ["visible"]
 build-server = ["pub-response-field"]
 
 [dependencies]
-tonic = "0.12.3"
+async-trait = "0.1"
+tonic = "0.13"
 prost = "0.13"
 tokio = "1.38"
 tokio-stream = "0.1"
 tower-service = "0.3"
 http = "1.1"
 visible = { version = "0.0.1", optional = true }
-tower = { version = "0.4", default-features = false }
+tower = { version = "0.5", default-features = false }
 openssl = { version = "0.10", optional = true }
 hyper = { version = "1.4", features = ["client"], optional = true }
 hyper-openssl = { version = "0.10", features = ["client-legacy", "tokio"], optional = true }
 hyper-util = { version = "0.1", features = ["client-legacy"], optional = true }
+futures = { version = "0.3", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1.38", features = ["full"] }
 
 [build-dependencies]
-tonic-build = { version = "0.12.3", default-features = false, features = ["prost"] }
+tonic-build = { version = "0.13", default-features = false, features = ["prost"] }
 
 [package.metadata.docs.rs]
 features = ["tls", "tls-roots"]

--- a/src/change.rs
+++ b/src/change.rs
@@ -1,0 +1,44 @@
+//! This module mainly provides [`EndpointUpdate`] trait.
+
+use std::sync::Arc;
+
+use http::Uri;
+use tokio::sync::mpsc::Sender;
+use tonic::transport::channel::Change as TonicChange;
+use tonic::transport::Endpoint;
+use tower::discover::Change as TowerChange;
+
+/// The trait is responsible for updating the endpoint.
+#[async_trait::async_trait]
+pub trait EndpointUpdate: Send + Sync + 'static {
+    /// Sends a endpoint change message.
+    async fn send(&self, change: TowerChange<Uri, Endpoint>);
+}
+
+pub type EndpointUpdateRef = Arc<dyn EndpointUpdate + Send + Sync>;
+
+pub struct TonicEndpointUpdater {
+    pub sender: Sender<TonicChange<Uri, Endpoint>>,
+}
+
+#[async_trait::async_trait]
+impl EndpointUpdate for TonicEndpointUpdater {
+    async fn send(&self, change: TowerChange<Uri, Endpoint>) {
+        let change = match change {
+            TowerChange::Insert(key, svc) => TonicChange::Insert(key, svc),
+            TowerChange::Remove(key) => TonicChange::Remove(key),
+        };
+        let _ = self.sender.send(change).await;
+    }
+}
+
+pub struct TowerEndpointUpdater {
+    pub sender: Sender<TowerChange<Uri, Endpoint>>,
+}
+
+#[async_trait::async_trait]
+impl EndpointUpdate for TowerEndpointUpdater {
+    async fn send(&self, change: TowerChange<Uri, Endpoint>) {
+        let _ = self.sender.send(change).await;
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 mod auth;
+mod change;
 mod channel;
 mod client;
 mod error;
@@ -68,6 +69,7 @@ mod openssl_tls;
 mod rpc;
 mod vec;
 
+pub use crate::change::EndpointUpdate;
 pub use crate::channel::{BalancedChannelBuilder, Channel};
 pub use crate::client::{Client, ConnectOptions};
 pub use crate::error::Error;


### PR DESCRIPTION
Hi, this pr upgrades tonic from 0.12 to 0.13.x. 

Note: 
1. enable `tonic/tls-ring` in `tls` feature.
2. add `EndpointUpdate` trait, in order to unify the `Change` structure of tonic and tower.

Related issues or PRs #100 