### PR TITLE
Set large-error-threshold to 256 for rust 1.87

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+large-error-threshold = 256


### PR DESCRIPTION
> ```
>  error: the `Err`-variant returned from this function is very large
>     --> src/client.rs:156:71
>      |
>  156 |     fn build_endpoint(url: &str, options: &Option<ConnectOptions>) -> Result<Endpoint> {
>      |                                                                       ^^^^^^^^^^^^^^^^
>      |
>     ::: src/error.rs:24:5
>      |
>  24  |     GRpcStatus(tonic::Status),
>      |     ------------------------- the largest variant contains at least 176 bytes
>      |
>      = help: try reducing the size of `error::Error`, for example by boxing large elements or replacing it with `Box<error::Error>`
>      = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#result_large_err
>      = note: `-D clippy::result-large-err` implied by `-D warnings`
>      = help: to override `-D warnings` add `#[allow(clippy::result_large_err)]`
> ```

Failure in the clippy check, but didn't change the `Error` type. Found that warning was shows from rust 1.87.0. https://github.com/hyperium/tonic/issues/2253
