### PR TITLE
Fix `Client` (`Channel`) `Sync`

### DIFF
--- a/src/channel.rs
+++ b/src/channel.rs
@@ -3,7 +3,7 @@ use std::{future::Future, pin::Pin, task::ready};
 use http::Uri;
 use tokio::sync::mpsc::Sender;
 use tonic::transport::{channel::Change, Endpoint};
-use tower::{util::BoxCloneService, Service};
+use tower::{util::BoxCloneSyncService, Service};
 
 /// A type alias to make the below types easier to represent.
 pub type EndpointUpdater = Sender<Change<Uri, Endpoint>>;
@@ -54,7 +54,7 @@ impl BalancedChannelBuilder for Openssl {
 
 type TonicRequest = http::Request<tonic::body::Body>;
 type TonicResponse = http::Response<tonic::body::Body>;
-pub type CustomChannel = BoxCloneService<TonicRequest, TonicResponse, tower::BoxError>;
+pub type CustomChannel = BoxCloneSyncService<TonicRequest, TonicResponse, tower::BoxError>;
 
 /// Represents a channel that can be created by a BalancedChannelBuilder
 /// or may be initialized externally and passed into the client.


### PR DESCRIPTION
Use `BoxCloneSyncService` instead of `BoxCloneService` for `CustomChannel` to keep Client Sync.

See #109

Introduced in #98