### PR TITLE
Expose watch_request::RequestUnion as PbWatchRequestUnion

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -210,4 +210,7 @@ pub mod proto {
         RangeRequest as PbRangeRequest, SnapshotRequest as PbSnapshotRequest,
         StatusRequest as PbStatusRequest, WatchRequest as PbWatchRequest,
     };
+
+    #[cfg(feature = "build-server")]
+    pub use crate::rpc::pb::etcdserverpb::watch_request::RequestUnion as PbWatchRequestUnion;
 }


### PR DESCRIPTION
In order to support deterministic simulation testing (DST) for watch events, this patch re-exports `watch_request::RequestUnion` as `PbWatchRequestUnion`, so it may be used by an external simulator crate. This has been tested internally, and is sufficient to write tests of this style. 
