### PR TITLE
add optional automatic token refresh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,12 +17,16 @@ jobs:
           sudo docker run -d --name etcd-server
           --publish 2379:2379
           --publish 2380:2380
+          --env ETCD_AUTH_TOKEN_TTL=2
           --env ALLOW_NONE_AUTHENTICATION=yes
           --env ETCD_LISTEN_CLIENT_URLS=http://0.0.0.0:2379
           --env ETCD_ADVERTISE_CLIENT_URLS=http://localhost:2379
           quay.io/coreos/etcd:v3.5.26
       - run: sudo docker exec etcd-server etcdctl member list -w table
       - run: sudo docker exec etcd-server etcdctl endpoint status -w table
+      # Create and grant a testing user.
+      - run: sudo docker exec etcd-server etcdctl user add --new-user-password="rootpwd" root
+      - run: sudo docker exec etcd-server etcdctl user grant-role root root
       - run: sudo apt install -y protobuf-compiler libprotobuf-dev curl
       - name: Check out repository code
         uses: actions/checkout@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ hyper-util = { version = "0.1", features = ["client-legacy"], optional = true }
 
 [dev-dependencies]
 tokio = { version = "1.38", features = ["full"] }
+serial_test = "3"
 
 [build-dependencies]
 tonic-build = { version = "0.14", default-features = false }

--- a/src/caller.rs
+++ b/src/caller.rs
@@ -1,0 +1,189 @@
+use std::{
+    future::Future,
+    sync::{Arc, RwLock},
+};
+
+use tonic::{
+    metadata::{Ascii, MetadataValue},
+    Code,
+};
+
+use crate::{
+    client::AuthToken, error::Result, intercept::InterceptedChannel, lock::RwLockExt, AuthClient,
+    Error::GRpcStatus,
+};
+
+/// Describe the options for the client request caller.
+#[derive(Clone)]
+pub struct CallOptions {
+    /// Authentication credentials if present.
+    pub creds: Arc<RwLock<Option<(String, String)>>>,
+    /// Whether to automatically refresh an expired token.
+    /// Requires each request cloning.
+    pub refresh_expired_token: bool,
+}
+
+/// Helps to build a [`ClientCaller`].
+#[derive(Clone)]
+pub struct ClientCallerBuilder {
+    options: CallOptions,
+    auth_token: AuthToken,
+    auth_client: AuthClient,
+    channel: InterceptedChannel,
+}
+
+impl ClientCallerBuilder {
+    /// Make a new [`ClientCallerBuilder`].
+    pub fn new(
+        options: CallOptions,
+        auth_token: AuthToken,
+        auth_client: AuthClient,
+        channel: InterceptedChannel,
+    ) -> Self {
+        Self {
+            options,
+            auth_token,
+            auth_client,
+            channel,
+        }
+    }
+
+    /// Build a new [`ClientCaller`] passing an actual client implementation.
+    pub fn build<T>(self, f_inner: impl FnOnce(InterceptedChannel) -> T) -> ClientCaller<T> {
+        ClientCaller::new(
+            f_inner(self.channel),
+            self.auth_client,
+            self.auth_token,
+            self.options,
+        )
+    }
+}
+
+/// This struct is responsible for dispatching the actions required for each
+/// client request. It is parameterized by the inner client implementation, so
+/// it can be reused across different clients. Its main method, [`do_call`],
+/// controls how a user request is performed. Currently, the only supported
+/// feature is automatic authentication token refresh upon expiration.
+///
+/// [`do_call`]: `ClientCaller::do_call`
+#[derive(Clone)]
+pub struct ClientCaller<T> {
+    inner: T,
+    auth_client: AuthClient,
+    auth_token: AuthToken,
+    options: CallOptions,
+}
+
+impl<T> ClientCaller<T> {
+    /// Make a new [`ClientCaller`].
+    pub fn new(
+        inner: T,
+        auth_client: AuthClient,
+        auth_token: AuthToken,
+        options: CallOptions,
+    ) -> Self {
+        Self {
+            inner,
+            auth_client,
+            auth_token,
+            options,
+        }
+    }
+
+    /// Refresh the authentication token if the client has credentials options.
+    pub async fn refresh_token(&self) -> Result<()> {
+        let creds = self.options.creds.read_unpoisoned().clone();
+        if let Some((user, password)) = creds {
+            let token = self.do_authenticate(user, password).await?;
+            self.auth_token.write_unpoisoned().replace(token);
+        } else {
+            let _ = self.auth_token.write_unpoisoned().take();
+        }
+        Ok(())
+    }
+
+    /// Update a user.
+    ///
+    /// Client will perform the authentication with the given user credentials. If successful, the
+    /// authentication token will be updated in the client. Nothing happens if the authentication
+    /// fails.
+    ///
+    /// If the user is `None`, it will remove the authentication token from the client.
+    pub async fn update_user(&mut self, creds: Option<(String, String)>) -> Result<()> {
+        if let Some((ref name, ref password)) = creds {
+            let token = self.do_authenticate(name.clone(), password.clone()).await?;
+            self.auth_token.write_unpoisoned().replace(token);
+        } else {
+            let _ = self.auth_token.write_unpoisoned().take();
+        }
+        *self.options.creds.write_unpoisoned() = creds;
+        Ok(())
+    }
+
+    /// Mutate an inner client.
+    pub fn with(mut self, f: impl FnOnce(T) -> T) -> Self {
+        self.inner = f(self.inner);
+        self
+    }
+
+    /// Performs a client request. Takes a request `req` and the function that
+    /// actually sends it.
+    ///
+    /// # Note
+    ///
+    /// The arguments are separate to support scenarios in which `req` is not
+    /// cloned. For example, passing a single closure would require an [`Fn`],
+    /// which would likely unconditionally clone the captured request.
+    pub async fn do_call<Req, C, Ret>(&mut self, req: Req, call: C) -> Result<Ret>
+    where
+        for<'a> C: ClientCall<&'a mut T, Req, Output = Result<Ret>>,
+        Req: Clone,
+    {
+        let has_creds = self.options.creds.read_unpoisoned().is_some();
+        if !self.options.refresh_expired_token || !has_creds {
+            // Refreshing is disabled or credentials are not set.
+            // Pass the request directly avoiding cloning.
+            return (call)(&mut self.inner, req).await;
+        }
+
+        // Clone the request to be able to retry in the case of token expiration.
+        let resp = (call)(&mut self.inner, req.clone()).await;
+        match resp {
+            Err(GRpcStatus(status)) if status.code() == Code::Unauthenticated => {
+                // Re-authenticate and retry this query.
+                self.refresh_token().await?;
+                (call)(&mut self.inner, req).await
+            }
+            res => res,
+        }
+    }
+
+    async fn do_authenticate(
+        &self,
+        user: String,
+        password: String,
+    ) -> Result<MetadataValue<Ascii>> {
+        let resp = self
+            .auth_client
+            .clone()
+            .authenticate(user, password)
+            .await?;
+        let token = resp.token().parse()?;
+        Ok(token)
+    }
+}
+
+/// The auxiliary trait to express an async call over the mutable client.
+pub trait ClientCall<Client, Req>: Fn(Client, Req) -> Self::OutputFuture {
+    type Output;
+    type OutputFuture: Future<Output = <Self as ClientCall<Client, Req>>::Output>;
+}
+
+impl<F, Fut, Client, Req> ClientCall<Client, Req> for F
+where
+    F: Fn(Client, Req) -> Fut,
+    Fut: Future,
+{
+    type OutputFuture = Fut;
+    type Output = Fut::Output;
+}

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,10 +1,10 @@
 //! Asynchronous client & synchronous client.
 
+use crate::caller::{CallOptions, ClientCaller, ClientCallerBuilder};
 #[cfg(feature = "raw-channel")]
 use crate::channel::Channel;
 use crate::error::{Error, Result};
 use crate::intercept::{InterceptedChannel, Interceptor};
-use crate::lock::RwLockExt;
 #[cfg(feature = "tls-openssl")]
 use crate::openssl_tls::{OpenSslClientConfig, OpenSslConnector};
 use crate::rpc::auth::Permission;
@@ -54,6 +54,8 @@ use tonic::transport::{channel::Change, Endpoint};
 const HTTP_PREFIX: &str = "http://";
 const HTTPS_PREFIX: &str = "https://";
 
+pub(crate) type AuthToken = Arc<RwLock<Option<MetadataValue<Ascii>>>>;
+
 /// Asynchronous `etcd` client using v3 API.
 #[derive(Clone)]
 pub struct Client {
@@ -65,9 +67,11 @@ pub struct Client {
     maintenance: MaintenanceClient,
     cluster: ClusterClient,
     election: ElectionClient,
+    /// Note: the relevant [`ConnectOptions::user`] maintenance is
+    /// the [`Self::client_caller`] responsibility.
     options: ConnectOptions,
     tx: Option<Sender<Change<Uri, Endpoint>>>,
-    auth_token: Arc<RwLock<Option<MetadataValue<Ascii>>>>,
+    client_caller: ClientCaller<()>,
 }
 
 impl Client {
@@ -246,14 +250,17 @@ impl Client {
         auth_token: Arc<RwLock<Option<MetadataValue<Ascii>>>>,
         options: ConnectOptions,
     ) -> Self {
-        let kv = KvClient::new(channel.clone());
-        let watch = WatchClient::new(channel.clone());
-        let lease = LeaseClient::new(channel.clone());
-        let lock = LockClient::new(channel.clone());
         let auth = AuthClient::new(channel.clone());
-        let cluster = ClusterClient::new(channel.clone());
-        let maintenance = MaintenanceClient::new(channel.clone());
-        let election = ElectionClient::new(channel);
+        let builder =
+            ClientCallerBuilder::new((&options).into(), auth_token, auth.clone(), channel);
+
+        let kv = KvClient::new(builder.clone());
+        let watch = WatchClient::new(builder.clone());
+        let lease = LeaseClient::new(builder.clone());
+        let lock = LockClient::new(builder.clone());
+        let cluster = ClusterClient::new(builder.clone());
+        let maintenance = MaintenanceClient::new(builder.clone());
+        let election = ElectionClient::new(builder.clone());
 
         Self {
             kv,
@@ -266,7 +273,7 @@ impl Client {
             election,
             options,
             tx,
-            auth_token,
+            client_caller: builder.build(|_| ()),
         }
     }
 
@@ -748,25 +755,9 @@ impl Client {
         self.election.resign(option).await
     }
 
-    async fn do_authenticate(
-        &self,
-        user: String,
-        password: String,
-    ) -> Result<MetadataValue<Ascii>> {
-        let resp = self.auth_client().authenticate(user, password).await?;
-        let token = resp.token().parse()?;
-        Ok(token)
-    }
-
     /// Refresh the authentication token if the client has credentials options.
     pub async fn refresh_token(&self) -> Result<()> {
-        if let Some((user, password)) = self.options.user.as_ref() {
-            let token = self.do_authenticate(user.clone(), password.clone()).await?;
-            self.auth_token.write_unpoisoned().replace(token);
-        } else {
-            let _ = self.auth_token.write_unpoisoned().take();
-        }
-        Ok(())
+        self.client_caller.refresh_token().await
     }
 
     /// Updates the user credentials for the client in flight.
@@ -777,14 +768,7 @@ impl Client {
     ///
     /// If the user is `None`, it will remove the authentication token from the client.
     pub async fn update_user(&mut self, user: Option<(String, String)>) -> Result<()> {
-        if let Some((ref name, ref password)) = user {
-            let token = self.do_authenticate(name.clone(), password.clone()).await?;
-            self.auth_token.write_unpoisoned().replace(token);
-        } else {
-            let _ = self.auth_token.write_unpoisoned().take();
-        }
-        self.options.user = user;
-        Ok(())
+        self.client_caller.update_user(user).await
     }
 }
 
@@ -809,6 +793,8 @@ pub struct ConnectOptions {
     otls: Option<OpenSslResult<OpenSslConnector>>,
     /// Require a leader to be present for the operation to complete.
     require_leader: bool,
+    /// Automatically refresh the authentication token on expiration.
+    refresh_expired_token: bool,
 }
 
 impl ConnectOptions {
@@ -889,6 +875,14 @@ impl ConnectOptions {
         self
     }
 
+    /// Whether to automatically refresh the authentication token when the current
+    /// token has expired. Note that, when this feature is enabled, each request is
+    /// *CLONED* so that it can be retried.
+    pub fn with_auto_token_refresh(mut self, refresh_expired_token: bool) -> Self {
+        self.refresh_expired_token = refresh_expired_token;
+        self
+    }
+
     /// Creates a `ConnectOptions`.
     #[inline]
     pub const fn new() -> Self {
@@ -904,6 +898,16 @@ impl ConnectOptions {
             #[cfg(feature = "tls-openssl")]
             otls: None,
             require_leader: false,
+            refresh_expired_token: false,
+        }
+    }
+}
+
+impl From<&ConnectOptions> for CallOptions {
+    fn from(options: &ConnectOptions) -> Self {
+        Self {
+            creds: Arc::new(RwLock::new(options.user.clone())),
+            refresh_expired_token: options.refresh_expired_token,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,6 +65,7 @@
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
+mod caller;
 mod channel;
 mod client;
 mod error;

--- a/src/rpc/cluster.rs
+++ b/src/rpc/cluster.rs
@@ -1,5 +1,6 @@
 //! Etcd Cluster RPC.
 
+use crate::caller::{ClientCaller, ClientCallerBuilder};
 use crate::error::Result;
 use crate::intercept::InterceptedChannel;
 use crate::rpc::pb::etcdserverpb::cluster_client::ClusterClient as PbClusterClient;
@@ -14,19 +15,22 @@ use crate::rpc::pb::etcdserverpb::{
 use crate::rpc::ResponseHeader;
 use tonic::{IntoRequest, Request};
 
+type Client = PbClusterClient<InterceptedChannel>;
+
 /// Client for Cluster operations.
 #[repr(transparent)]
 #[derive(Clone)]
 pub struct ClusterClient {
-    inner: PbClusterClient<InterceptedChannel>,
+    inner: ClientCaller<Client>,
 }
 
 impl ClusterClient {
     /// Creates an Cluster client.
     #[inline]
-    pub(crate) fn new(channel: InterceptedChannel) -> Self {
-        let inner = PbClusterClient::new(channel);
-        Self { inner }
+    pub(crate) fn new(builder: ClientCallerBuilder) -> Self {
+        Self {
+            inner: builder.build(Client::new),
+        }
     }
 
     /// Adds a new member into the cluster.
@@ -36,24 +40,31 @@ impl ClusterClient {
         urls: impl Into<Vec<String>>,
         options: Option<MemberAddOptions>,
     ) -> Result<MemberAddResponse> {
-        let resp = self
-            .inner
-            .member_add(options.unwrap_or_default().with_urls(urls))
-            .await?
-            .into_inner();
-
-        Ok(MemberAddResponse::new(resp))
+        async fn member_add_impl(
+            client: &mut Client,
+            options: MemberAddOptions,
+        ) -> Result<MemberAddResponse> {
+            let resp = client.member_add(options).await?.into_inner();
+            Ok(MemberAddResponse::new(resp))
+        }
+        self.inner
+            .do_call(options.unwrap_or_default().with_urls(urls), member_add_impl)
+            .await
     }
 
     /// Removes an existing member from the cluster.
     #[inline]
     pub async fn member_remove(&mut self, id: u64) -> Result<MemberRemoveResponse> {
-        let resp = self
-            .inner
-            .member_remove(MemberRemoveOptions::new().with_id(id))
-            .await?
-            .into_inner();
-        Ok(MemberRemoveResponse::new(resp))
+        async fn member_remove_impl(
+            client: &mut Client,
+            options: MemberRemoveOptions,
+        ) -> Result<MemberRemoveResponse> {
+            let resp = client.member_remove(options).await?.into_inner();
+            Ok(MemberRemoveResponse::new(resp))
+        }
+        self.inner
+            .do_call(MemberRemoveOptions::new().with_id(id), member_remove_impl)
+            .await
     }
 
     /// Updates the member configuration.
@@ -63,34 +74,49 @@ impl ClusterClient {
         id: u64,
         url: impl Into<Vec<String>>,
     ) -> Result<MemberUpdateResponse> {
-        let resp = self
-            .inner
-            .member_update(MemberUpdateOptions::new().with_option(id, url))
-            .await?
-            .into_inner();
-        Ok(MemberUpdateResponse::new(resp))
+        async fn member_update_impl(
+            client: &mut Client,
+            options: MemberUpdateOptions,
+        ) -> Result<MemberUpdateResponse> {
+            let resp = client.member_update(options).await?.into_inner();
+            Ok(MemberUpdateResponse::new(resp))
+        }
+        self.inner
+            .do_call(
+                MemberUpdateOptions::new().with_option(id, url),
+                member_update_impl,
+            )
+            .await
     }
 
     /// Lists all the members in the cluster.
     #[inline]
     pub async fn member_list(&mut self) -> Result<MemberListResponse> {
-        let resp = self
-            .inner
-            .member_list(PbMemberListRequest {})
-            .await?
-            .into_inner();
-        Ok(MemberListResponse::new(resp))
+        async fn member_list_impl(
+            client: &mut Client,
+            options: PbMemberListRequest,
+        ) -> Result<MemberListResponse> {
+            let resp = client.member_list(options).await?.into_inner();
+            Ok(MemberListResponse::new(resp))
+        }
+        self.inner
+            .do_call(PbMemberListRequest {}, member_list_impl)
+            .await
     }
 
     /// Promotes a member from raft learner (non-voting) to raft voting member.
     #[inline]
     pub async fn member_promote(&mut self, id: u64) -> Result<MemberPromoteResponse> {
-        let resp = self
-            .inner
-            .member_promote(MemberPromoteOptions::new().with_id(id))
-            .await?
-            .into_inner();
-        Ok(MemberPromoteResponse::new(resp))
+        async fn member_promote_impl(
+            client: &mut Client,
+            options: MemberPromoteOptions,
+        ) -> Result<MemberPromoteResponse> {
+            let resp = client.member_promote(options).await?.into_inner();
+            Ok(MemberPromoteResponse::new(resp))
+        }
+        self.inner
+            .do_call(MemberPromoteOptions::new().with_id(id), member_promote_impl)
+            .await
     }
 }
 

--- a/src/rpc/election.rs
+++ b/src/rpc/election.rs
@@ -1,5 +1,6 @@
 //! Etcd Election RPC.
 
+use crate::caller::{ClientCaller, ClientCallerBuilder};
 use crate::error::Result;
 use crate::intercept::InterceptedChannel;
 use crate::rpc::pb::v3electionpb::election_client::ElectionClient as PbElectionClient;
@@ -15,11 +16,13 @@ use std::task::{Context, Poll};
 use tokio_stream::Stream;
 use tonic::{IntoRequest, Request, Streaming};
 
+type Client = PbElectionClient<InterceptedChannel>;
+
 /// Client for Elect operations.
 #[repr(transparent)]
 #[derive(Clone)]
 pub struct ElectionClient {
-    inner: PbElectionClient<InterceptedChannel>,
+    inner: ClientCaller<Client>,
 }
 
 /// Options for `campaign` operation.
@@ -484,9 +487,10 @@ impl From<&PbLeaderKey> for &LeaderKey {
 impl ElectionClient {
     /// Creates a election
     #[inline]
-    pub(crate) fn new(channel: InterceptedChannel) -> Self {
-        let inner = PbElectionClient::new(channel);
-        Self { inner }
+    pub(crate) fn new(builder: ClientCallerBuilder) -> Self {
+        Self {
+            inner: builder.build(Client::new),
+        }
     }
 
     /// Puts a value as eligible for the election on the prefix key.
@@ -499,17 +503,23 @@ impl ElectionClient {
         value: impl Into<Vec<u8>>,
         lease: i64,
     ) -> Result<CampaignResponse> {
-        let resp = self
-            .inner
-            .campaign(
+        async fn campaign_impl(
+            client: &mut Client,
+            options: CampaignOptions,
+        ) -> Result<CampaignResponse> {
+            let resp = client.campaign(options).await?.into_inner();
+            Ok(CampaignResponse::new(resp))
+        }
+
+        self.inner
+            .do_call(
                 CampaignOptions::new()
                     .with_name(name)
                     .with_value(value)
                     .with_lease(lease),
+                campaign_impl,
             )
-            .await?
-            .into_inner();
-        Ok(CampaignResponse::new(resp))
+            .await
     }
 
     /// Lets the leader announce a new value without another election.
@@ -519,46 +529,61 @@ impl ElectionClient {
         value: impl Into<Vec<u8>>,
         options: Option<ProclaimOptions>,
     ) -> Result<ProclaimResponse> {
-        let resp = self
-            .inner
-            .proclaim(options.unwrap_or_default().with_value(value))
-            .await?
-            .into_inner();
-        Ok(ProclaimResponse::new(resp))
+        async fn proclaim_impl(
+            client: &mut Client,
+            options: ProclaimOptions,
+        ) -> Result<ProclaimResponse> {
+            let resp = client.proclaim(options).await?.into_inner();
+            Ok(ProclaimResponse::new(resp))
+        }
+        self.inner
+            .do_call(options.unwrap_or_default().with_value(value), proclaim_impl)
+            .await
     }
 
     /// Returns the leader value for the current election.
     #[inline]
     pub async fn leader(&mut self, name: impl Into<Vec<u8>>) -> Result<LeaderResponse> {
-        let resp = self
-            .inner
-            .leader(LeaderOptions::new().with_name(name))
-            .await?
-            .into_inner();
-        Ok(LeaderResponse::new(resp))
+        async fn leader_impl(
+            client: &mut Client,
+            options: LeaderOptions,
+        ) -> Result<LeaderResponse> {
+            let resp = client.leader(options).await?.into_inner();
+            Ok(LeaderResponse::new(resp))
+        }
+        self.inner
+            .do_call(LeaderOptions::new().with_name(name), leader_impl)
+            .await
     }
 
     /// Returns a channel that reliably observes ordered leader proposals
     /// as GetResponse values on every current elected leader key.
     #[inline]
     pub async fn observe(&mut self, name: impl Into<Vec<u8>>) -> Result<ObserveStream> {
-        let resp = self
-            .inner
-            .observe(LeaderOptions::new().with_name(name))
-            .await?
-            .into_inner();
-
-        Ok(ObserveStream::new(resp))
+        async fn observe_impl(
+            client: &mut Client,
+            options: LeaderOptions,
+        ) -> Result<ObserveStream> {
+            let resp = client.observe(options).await?.into_inner();
+            Ok(ObserveStream::new(resp))
+        }
+        self.inner
+            .do_call(LeaderOptions::new().with_name(name), observe_impl)
+            .await
     }
 
     /// Releases election leadership and then start a new election
     #[inline]
     pub async fn resign(&mut self, option: Option<ResignOptions>) -> Result<ResignResponse> {
-        let resp = self
-            .inner
-            .resign(option.unwrap_or_default())
-            .await?
-            .into_inner();
-        Ok(ResignResponse::new(resp))
+        async fn resign_impl(
+            client: &mut Client,
+            options: ResignOptions,
+        ) -> Result<ResignResponse> {
+            let resp = client.resign(options).await?.into_inner();
+            Ok(ResignResponse::new(resp))
+        }
+        self.inner
+            .do_call(option.unwrap_or_default(), resign_impl)
+            .await
     }
 }

--- a/src/rpc/kv.rs
+++ b/src/rpc/kv.rs
@@ -1,5 +1,6 @@
 //! Etcd KV Operations.
 
+use crate::caller::{ClientCaller, ClientCallerBuilder};
 pub use crate::rpc::pb::etcdserverpb::compare::CompareResult as CompareOp;
 pub use crate::rpc::pb::etcdserverpb::range_request::{SortOrder, SortTarget};
 
@@ -22,26 +23,31 @@ use crate::vec::VecExt;
 use std::mem::ManuallyDrop;
 use tonic::{IntoRequest, Request};
 
+type Client = PbKvClient<InterceptedChannel>;
+
 /// Client for KV operations.
 #[repr(transparent)]
 #[derive(Clone)]
 pub struct KvClient {
-    inner: PbKvClient<InterceptedChannel>,
+    inner: ClientCaller<Client>,
 }
 
 impl KvClient {
     /// Creates a kv client.
     #[inline]
-    pub(crate) fn new(channel: InterceptedChannel) -> Self {
-        let inner = PbKvClient::new(channel);
-        Self { inner }
+    pub(crate) fn new(builder: ClientCallerBuilder) -> Self {
+        Self {
+            inner: builder.build(Client::new),
+        }
     }
 
     /// Limits the maximum size of a decoded message.
     ///
     /// Default: `4MB`
     pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
-        self.inner = self.inner.max_decoding_message_size(limit);
+        self.inner = self
+            .inner
+            .with(|client| client.max_decoding_message_size(limit));
         self
     }
 
@@ -49,7 +55,9 @@ impl KvClient {
     ///
     /// Default: `usize::MAX`
     pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
-        self.inner = self.inner.max_encoding_message_size(limit);
+        self.inner = self
+            .inner
+            .with(|client| client.max_encoding_message_size(limit));
         self
     }
 
@@ -63,12 +71,13 @@ impl KvClient {
         value: impl Into<Vec<u8>>,
         options: Option<PutOptions>,
     ) -> Result<PutResponse> {
-        let resp = self
-            .inner
-            .put(options.unwrap_or_default().with_kv(key, value))
-            .await?
-            .into_inner();
-        Ok(PutResponse::new(resp))
+        async fn put_impl(client: &mut Client, req: PutOptions) -> Result<PutResponse> {
+            let resp = client.put(req).await?.into_inner();
+            Ok(PutResponse::new(resp))
+        }
+        self.inner
+            .do_call(options.unwrap_or_default().with_kv(key, value), put_impl)
+            .await
     }
 
     /// Gets the key or a range of keys from the store.
@@ -78,12 +87,13 @@ impl KvClient {
         key: impl Into<Vec<u8>>,
         options: Option<GetOptions>,
     ) -> Result<GetResponse> {
-        let resp = self
-            .inner
-            .range(options.unwrap_or_default().with_key(key.into()))
-            .await?
-            .into_inner();
-        Ok(GetResponse::new(resp))
+        async fn get_impl(client: &mut Client, req: GetOptions) -> Result<GetResponse> {
+            let resp = client.range(req).await?.into_inner();
+            Ok(GetResponse::new(resp))
+        }
+        self.inner
+            .do_call(options.unwrap_or_default().with_key(key.into()), get_impl)
+            .await
     }
 
     /// Deletes the given key or a range of keys from the key-value store.
@@ -93,12 +103,16 @@ impl KvClient {
         key: impl Into<Vec<u8>>,
         options: Option<DeleteOptions>,
     ) -> Result<DeleteResponse> {
-        let resp = self
-            .inner
-            .delete_range(options.unwrap_or_default().with_key(key.into()))
-            .await?
-            .into_inner();
-        Ok(DeleteResponse::new(resp))
+        async fn delete_impl(client: &mut Client, req: DeleteOptions) -> Result<DeleteResponse> {
+            let resp = client.delete_range(req).await?.into_inner();
+            Ok(DeleteResponse::new(resp))
+        }
+        self.inner
+            .do_call(
+                options.unwrap_or_default().with_key(key.into()),
+                delete_impl,
+            )
+            .await
     }
 
     /// Compacts the event history in the etcd key-value store. The key-value
@@ -110,12 +124,19 @@ impl KvClient {
         revision: i64,
         options: Option<CompactionOptions>,
     ) -> Result<CompactionResponse> {
-        let resp = self
-            .inner
-            .compact(options.unwrap_or_default().with_revision(revision))
-            .await?
-            .into_inner();
-        Ok(CompactionResponse::new(resp))
+        async fn compact_impl(
+            client: &mut Client,
+            req: CompactionOptions,
+        ) -> Result<CompactionResponse> {
+            let resp = client.compact(req).await?.into_inner();
+            Ok(CompactionResponse::new(resp))
+        }
+        self.inner
+            .do_call(
+                options.unwrap_or_default().with_revision(revision),
+                compact_impl,
+            )
+            .await
     }
 
     /// Processes multiple operations in a single transaction.
@@ -124,8 +145,11 @@ impl KvClient {
     /// It is not allowed to modify the same key several times within one txn.
     #[inline]
     pub async fn txn(&mut self, txn: Txn) -> Result<TxnResponse> {
-        let resp = self.inner.txn(txn).await?.into_inner();
-        Ok(TxnResponse::new(resp))
+        async fn txn_impl(client: &mut Client, txn: Txn) -> Result<TxnResponse> {
+            let resp = client.txn(txn).await?.into_inner();
+            Ok(TxnResponse::new(resp))
+        }
+        self.inner.do_call(txn, txn_impl).await
     }
 }
 

--- a/src/rpc/lease.rs
+++ b/src/rpc/lease.rs
@@ -1,5 +1,6 @@
 //! Etcd Lease RPC.
 
+use crate::caller::{ClientCaller, ClientCallerBuilder};
 use crate::error::Result;
 use crate::intercept::InterceptedChannel;
 use crate::rpc::pb::etcdserverpb::lease_client::LeaseClient as PbLeaseClient;
@@ -22,19 +23,22 @@ use tokio_stream::wrappers::ReceiverStream;
 use tokio_stream::Stream;
 use tonic::{IntoRequest, Request, Streaming};
 
+type Client = PbLeaseClient<InterceptedChannel>;
+
 /// Client for lease operations.
 #[repr(transparent)]
 #[derive(Clone)]
 pub struct LeaseClient {
-    inner: PbLeaseClient<InterceptedChannel>,
+    inner: ClientCaller<Client>,
 }
 
 impl LeaseClient {
     /// Creates a `LeaseClient`.
     #[inline]
-    pub(crate) fn new(channel: InterceptedChannel) -> Self {
-        let inner = PbLeaseClient::new(channel);
-        Self { inner }
+    pub(crate) fn new(builder: ClientCallerBuilder) -> Self {
+        Self {
+            inner: builder.build(Client::new),
+        }
     }
 
     /// Creates a lease which expires if the server does not receive a keepAlive
@@ -46,38 +50,64 @@ impl LeaseClient {
         ttl: i64,
         options: Option<LeaseGrantOptions>,
     ) -> Result<LeaseGrantResponse> {
-        let resp = self
-            .inner
-            .lease_grant(options.unwrap_or_default().with_ttl(ttl))
-            .await?
-            .into_inner();
-        Ok(LeaseGrantResponse::new(resp))
+        async fn grant_impl(
+            client: &mut Client,
+            options: LeaseGrantOptions,
+        ) -> Result<LeaseGrantResponse> {
+            Ok(LeaseGrantResponse::new(
+                client.lease_grant(options).await?.into_inner(),
+            ))
+        }
+        self.inner
+            .do_call(options.unwrap_or_default().with_ttl(ttl), grant_impl)
+            .await
     }
 
     /// Revokes a lease. All keys attached to the lease will expire and be deleted.
     #[inline]
     pub async fn revoke(&mut self, id: i64) -> Result<LeaseRevokeResponse> {
-        let resp = self
-            .inner
-            .lease_revoke(LeaseRevokeOptions::new().with_id(id))
-            .await?
-            .into_inner();
-        Ok(LeaseRevokeResponse::new(resp))
+        async fn revoke_impl(
+            client: &mut Client,
+            options: LeaseRevokeOptions,
+        ) -> Result<LeaseRevokeResponse> {
+            let resp = client.lease_revoke(options).await?.into_inner();
+            Ok(LeaseRevokeResponse::new(resp))
+        }
+
+        self.inner
+            .do_call(LeaseRevokeOptions::new().with_id(id), revoke_impl)
+            .await
     }
 
     /// Keeps the lease alive by streaming keep alive requests from the client
     /// to the server and streaming keep alive responses from the server to the client.
     #[inline]
     pub async fn keep_alive(&mut self, id: i64) -> Result<(LeaseKeeper, LeaseKeepAliveStream)> {
-        let (sender, receiver) = channel::<PbLeaseKeepAliveRequest>(100);
-        sender
-            .send(LeaseKeepAliveOptions::new().with_id(id).into())
-            .await
-            .map_err(|e| Error::LeaseKeepAliveError(e.to_string()))?;
+        async fn keep_alive_impl(
+            client: &mut Client,
+            options: PbLeaseKeepAliveRequest,
+        ) -> Result<(
+            Sender<PbLeaseKeepAliveRequest>,
+            Streaming<PbLeaseKeepAliveResponse>,
+        )> {
+            let (sender, receiver) = channel::<PbLeaseKeepAliveRequest>(100);
+            sender
+                .send(options)
+                .await
+                .map_err(|e| Error::LeaseKeepAliveError(e.to_string()))?;
 
-        let receiver = ReceiverStream::new(receiver);
+            let receiver = ReceiverStream::new(receiver);
+            let resp = client.lease_keep_alive(receiver).await?.into_inner();
+            Ok((sender, resp))
+        }
 
-        let mut stream = self.inner.lease_keep_alive(receiver).await?.into_inner();
+        let (sender, mut stream) = self
+            .inner
+            .do_call(
+                LeaseKeepAliveOptions::new().with_id(id).into(),
+                keep_alive_impl,
+            )
+            .await?;
 
         let id = match stream.message().await? {
             Some(resp) => {
@@ -106,23 +136,33 @@ impl LeaseClient {
         id: i64,
         options: Option<LeaseTimeToLiveOptions>,
     ) -> Result<LeaseTimeToLiveResponse> {
-        let resp = self
-            .inner
-            .lease_time_to_live(options.unwrap_or_default().with_id(id))
-            .await?
-            .into_inner();
-        Ok(LeaseTimeToLiveResponse::new(resp))
+        async fn time_to_live_impl(
+            client: &mut Client,
+            options: LeaseTimeToLiveOptions,
+        ) -> Result<LeaseTimeToLiveResponse> {
+            let resp = client.lease_time_to_live(options).await?.into_inner();
+            Ok(LeaseTimeToLiveResponse::new(resp))
+        }
+
+        self.inner
+            .do_call(options.unwrap_or_default().with_id(id), time_to_live_impl)
+            .await
     }
 
     /// Lists all existing leases.
     #[inline]
     pub async fn leases(&mut self) -> Result<LeaseLeasesResponse> {
-        let resp = self
-            .inner
-            .lease_leases(PbLeaseLeasesRequest {})
-            .await?
-            .into_inner();
-        Ok(LeaseLeasesResponse::new(resp))
+        async fn leases_impl(
+            client: &mut Client,
+            req: PbLeaseLeasesRequest,
+        ) -> Result<LeaseLeasesResponse> {
+            let resp = client.lease_leases(req).await?.into_inner();
+            Ok(LeaseLeasesResponse::new(resp))
+        }
+
+        self.inner
+            .do_call(PbLeaseLeasesRequest {}, leases_impl)
+            .await
     }
 }
 

--- a/src/rpc/lock.rs
+++ b/src/rpc/lock.rs
@@ -1,6 +1,7 @@
 //! Etcd Lock RPC.
 
 use super::pb::v3lockpb;
+use crate::caller::{ClientCaller, ClientCallerBuilder};
 use crate::error::Result;
 use crate::intercept::InterceptedChannel;
 use crate::rpc::ResponseHeader;
@@ -11,21 +12,23 @@ use v3lockpb::{
     UnlockResponse as PbUnlockResponse,
 };
 
+type Client = PbLockClient<InterceptedChannel>;
+
 /// Client for Lock operations.
 #[repr(transparent)]
 #[derive(Clone)]
 pub struct LockClient {
-    inner: PbLockClient<InterceptedChannel>,
+    inner: ClientCaller<Client>,
 }
 
 impl LockClient {
     /// Creates a lock client.
     #[inline]
-    pub(crate) fn new(channel: InterceptedChannel) -> Self {
-        let inner = PbLockClient::new(channel);
-        Self { inner }
+    pub(crate) fn new(builder: ClientCallerBuilder) -> Self {
+        Self {
+            inner: builder.build(Client::new),
+        }
     }
-
     /// Acquires a distributed shared lock on a given named lock.
     /// On success, it will return a unique key that exists so long as the
     /// lock is held by the caller. This key can be used in conjunction with
@@ -38,12 +41,13 @@ impl LockClient {
         name: impl Into<Vec<u8>>,
         options: Option<LockOptions>,
     ) -> Result<LockResponse> {
-        let resp = self
-            .inner
-            .lock(options.unwrap_or_default().with_name(name))
-            .await?
-            .into_inner();
-        Ok(LockResponse::new(resp))
+        async fn lock_impl(client: &mut Client, options: LockOptions) -> Result<LockResponse> {
+            let resp = client.lock(options).await?.into_inner();
+            Ok(LockResponse::new(resp))
+        }
+        self.inner
+            .do_call(options.unwrap_or_default().with_name(name), lock_impl)
+            .await
     }
 
     /// Takes a key returned by Lock and releases the hold on lock. The
@@ -51,12 +55,16 @@ impl LockClient {
     /// ownership of the lock.
     #[inline]
     pub async fn unlock(&mut self, key: impl Into<Vec<u8>>) -> Result<UnlockResponse> {
-        let resp = self
-            .inner
-            .unlock(UnlockOptions::new().with_key(key))
-            .await?
-            .into_inner();
-        Ok(UnlockResponse::new(resp))
+        async fn unlock_impl(
+            client: &mut Client,
+            options: UnlockOptions,
+        ) -> Result<UnlockResponse> {
+            let resp = client.unlock(options).await?.into_inner();
+            Ok(UnlockResponse::new(resp))
+        }
+        self.inner
+            .do_call(UnlockOptions::new().with_key(key), unlock_impl)
+            .await
     }
 }
 

--- a/src/rpc/maintenance.rs
+++ b/src/rpc/maintenance.rs
@@ -1,5 +1,6 @@
 //! Etcd Maintenance RPC.
 
+use crate::caller::{ClientCaller, ClientCallerBuilder};
 pub use crate::rpc::pb::etcdserverpb::alarm_request::AlarmAction;
 pub use crate::rpc::pb::etcdserverpb::AlarmType;
 
@@ -21,11 +22,13 @@ use etcdserverpb::AlarmMember as PbAlarmMember;
 use tonic::codec::Streaming as PbStreaming;
 use tonic::{IntoRequest, Request};
 
+type Client = PbMaintenanceClient<InterceptedChannel>;
+
 /// Client for maintenance operations.
 #[repr(transparent)]
 #[derive(Clone)]
 pub struct MaintenanceClient {
-    inner: PbMaintenanceClient<InterceptedChannel>,
+    inner: ClientCaller<Client>,
 }
 
 /// Options for `alarm` operation.
@@ -553,9 +556,10 @@ impl MoveLeaderResponse {
 impl MaintenanceClient {
     /// Creates a maintenance client.
     #[inline]
-    pub(crate) fn new(channel: InterceptedChannel) -> Self {
-        let inner = PbMaintenanceClient::new(channel);
-        Self { inner }
+    pub(crate) fn new(builder: ClientCallerBuilder) -> Self {
+        Self {
+            inner: builder.build(Client::new),
+        }
     }
 
     /// Get or active or inactive alarm.
@@ -566,34 +570,46 @@ impl MaintenanceClient {
         alarm_type: AlarmType,
         options: Option<AlarmOptions>,
     ) -> Result<AlarmResponse> {
-        let resp = self
-            .inner
-            .alarm(
+        async fn alarm_impl(client: &mut Client, options: AlarmOptions) -> Result<AlarmResponse> {
+            let resp = client.alarm(options).await?.into_inner();
+            Ok(AlarmResponse::new(resp))
+        }
+        self.inner
+            .do_call(
                 options
                     .unwrap_or_default()
                     .with_action_and_type(alarm_action, alarm_type),
+                alarm_impl,
             )
-            .await?
-            .into_inner();
-        Ok(AlarmResponse::new(resp))
+            .await
     }
 
     /// Get status of a member.
     #[inline]
     pub async fn status(&mut self) -> Result<StatusResponse> {
-        let resp = self.inner.status(StatusOptions::new()).await?.into_inner();
-        Ok(StatusResponse::new(resp))
+        async fn status_impl(
+            client: &mut Client,
+            options: StatusOptions,
+        ) -> Result<StatusResponse> {
+            let resp = client.status(options).await?.into_inner();
+            Ok(StatusResponse::new(resp))
+        }
+        self.inner.do_call(StatusOptions::new(), status_impl).await
     }
 
     /// Defragment a member's backend database to recover storage space.
     #[inline]
     pub async fn defragment(&mut self) -> Result<DefragmentResponse> {
-        let resp = self
-            .inner
-            .defragment(DefragmentOptions::new())
-            .await?
-            .into_inner();
-        Ok(DefragmentResponse::new(resp))
+        async fn defragment_impl(
+            client: &mut Client,
+            options: DefragmentOptions,
+        ) -> Result<DefragmentResponse> {
+            let resp = client.defragment(options).await?.into_inner();
+            Ok(DefragmentResponse::new(resp))
+        }
+        self.inner
+            .do_call(DefragmentOptions::new(), defragment_impl)
+            .await
     }
 
     /// Computes the hash of whole backend keyspace.
@@ -601,41 +617,59 @@ impl MaintenanceClient {
     /// This is designed for testing ONLY!
     #[inline]
     pub async fn hash(&mut self) -> Result<HashResponse> {
-        let resp = self.inner.hash(HashOptions::new()).await?.into_inner();
-        Ok(HashResponse::new(resp))
+        async fn hash_impl(client: &mut Client, options: HashOptions) -> Result<HashResponse> {
+            let resp = client.hash(options).await?.into_inner();
+            Ok(HashResponse::new(resp))
+        }
+        self.inner.do_call(HashOptions::new(), hash_impl).await
     }
 
     /// Computes the hash of all MVCC keys up to a given revision.
     /// It only iterates \"key\" bucket in backend storage.
     #[inline]
     pub async fn hash_kv(&mut self, revision: i64) -> Result<HashKvResponse> {
-        let resp = self
-            .inner
-            .hash_kv(HashKvOptions::new(revision))
-            .await?
-            .into_inner();
-        Ok(HashKvResponse::new(resp))
+        async fn hash_kv_impl(
+            client: &mut Client,
+            options: HashKvOptions,
+        ) -> Result<HashKvResponse> {
+            let resp = client.hash_kv(options).await?.into_inner();
+            Ok(HashKvResponse::new(resp))
+        }
+        self.inner
+            .do_call(HashKvOptions::new(revision), hash_kv_impl)
+            .await
     }
 
     /// Gets a snapshot of the entire backend from a member over a stream to a client.
     #[inline]
     pub async fn snapshot(&mut self) -> Result<SnapshotStreaming> {
-        let resp = self
-            .inner
-            .snapshot(SnapshotOptions::new())
-            .await?
-            .into_inner();
-        Ok(SnapshotStreaming(resp))
+        async fn snapshot_impl(
+            client: &mut Client,
+            options: SnapshotOptions,
+        ) -> Result<SnapshotStreaming> {
+            let resp = client.snapshot(options).await?.into_inner();
+            Ok(SnapshotStreaming(resp))
+        }
+        self.inner
+            .do_call(SnapshotOptions::new(), snapshot_impl)
+            .await
     }
 
     /// Moves the current leader node to target node.
     #[inline]
     pub async fn move_leader(&mut self, target_id: u64) -> Result<MoveLeaderResponse> {
-        let resp = self
-            .inner
-            .move_leader(MoveLeaderOptions::new().with_target_id(target_id))
-            .await?
-            .into_inner();
-        Ok(MoveLeaderResponse::new(resp))
+        async fn move_leader_impl(
+            client: &mut Client,
+            options: MoveLeaderOptions,
+        ) -> Result<MoveLeaderResponse> {
+            let resp = client.move_leader(options).await?.into_inner();
+            Ok(MoveLeaderResponse::new(resp))
+        }
+        self.inner
+            .do_call(
+                MoveLeaderOptions::new().with_target_id(target_id),
+                move_leader_impl,
+            )
+            .await
     }
 }

--- a/src/rpc/watch.rs
+++ b/src/rpc/watch.rs
@@ -1,5 +1,6 @@
 //! Etcd Watch RPC.
 
+use crate::caller::{ClientCaller, ClientCallerBuilder};
 pub use crate::rpc::pb::mvccpb::event::EventType;
 
 use crate::error::{Error, Result};
@@ -18,26 +19,31 @@ use tokio::sync::mpsc::{channel, Sender};
 use tokio_stream::{wrappers::ReceiverStream, Stream};
 use tonic::Streaming;
 
+type Client = PbWatchClient<InterceptedChannel>;
+
 /// Client for watch operations.
 #[repr(transparent)]
 #[derive(Clone)]
 pub struct WatchClient {
-    inner: PbWatchClient<InterceptedChannel>,
+    inner: ClientCaller<Client>,
 }
 
 impl WatchClient {
     /// Creates a watch client.
     #[inline]
-    pub(crate) fn new(channel: InterceptedChannel) -> Self {
-        let inner = PbWatchClient::new(channel);
-        Self { inner }
+    pub(crate) fn new(builder: ClientCallerBuilder) -> Self {
+        Self {
+            inner: builder.build(Client::new),
+        }
     }
 
     /// Limits the maximum size of a decoded message.
     ///
     /// Default: `4MB`
     pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
-        self.inner = self.inner.max_decoding_message_size(limit);
+        self.inner = self
+            .inner
+            .with(|client| client.max_decoding_message_size(limit));
         self
     }
 
@@ -53,14 +59,19 @@ impl WatchClient {
         key: impl Into<Vec<u8>>,
         options: Option<WatchOptions>,
     ) -> Result<WatchStream> {
-        let (request_sender, request_receiver) = channel::<WatchRequest>(100);
-        request_sender
-            .send(options.unwrap_or_default().with_key(key).into())
+        async fn watch_impl(client: &mut Client, options: WatchOptions) -> Result<WatchStream> {
+            let (request_sender, request_receiver) = channel::<WatchRequest>(100);
+            request_sender
+                .send(options.into())
+                .await
+                .map_err(|e| Error::WatchError(e.to_string()))?;
+            let request_stream = ReceiverStream::new(request_receiver);
+            let stream = client.watch(request_stream).await?.into_inner();
+            Ok(WatchStream::new(request_sender, stream))
+        }
+        self.inner
+            .do_call(options.unwrap_or_default().with_key(key), watch_impl)
             .await
-            .map_err(|e| Error::WatchError(e.to_string()))?;
-        let request_stream = ReceiverStream::new(request_receiver);
-        let response_stream = self.inner.watch(request_stream).await?.into_inner();
-        Ok(WatchStream::new(request_sender, response_stream))
     }
 }
 

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -1,11 +1,13 @@
 mod testing;
 
-use crate::testing::{get_client, Result, DEFAULT_TEST_ENDPOINT};
+use std::time::Duration;
+
+use crate::testing::{get_auth_client, get_client, Result, DEFAULT_TEST_ENDPOINT};
 use etcd_client::{
-    AlarmAction, AlarmOptions, AlarmType, Client, Compare, CompareOp, ConnectOptions,
-    DeleteOptions, EventType, GetOptions, LeaseGrantOptions, MemberAddOptions, Permission,
-    PermissionType, ProclaimOptions, PutOptions, ResignOptions, RoleRevokePermissionOptions, Txn,
-    TxnOp, TxnOpResponse, UserAddOptions,
+    AlarmAction, AlarmOptions, AlarmType, Compare, CompareOp, ConnectOptions, DeleteOptions,
+    EventType, GetOptions, LeaseGrantOptions, MemberAddOptions, Permission, PermissionType,
+    ProclaimOptions, PutOptions, ResignOptions, RoleRevokePermissionOptions, Txn, TxnOp,
+    TxnOpResponse, UserAddOptions,
 };
 
 #[tokio::test]
@@ -387,11 +389,7 @@ async fn test_auth() -> Result<()> {
     client.put("auth-test", "value", None).await.unwrap_err();
 
     // connect with authenticate, the user must already exists
-    let options = Some(ConnectOptions::new().with_user(
-        "root",    // user name
-        "rootpwd", // password
-    ));
-    let mut client_auth = Client::connect(["localhost:2379"], options).await?;
+    let mut client_auth = get_auth_client(None).await?;
     client_auth.put("auth-test", "value", None).await?;
 
     client_auth.auth_disable().await?;
@@ -403,12 +401,40 @@ async fn test_auth() -> Result<()> {
     Ok(())
 }
 
+#[ignore]
+#[tokio::test]
+async fn test_auth_refresh_token() -> Result<()> {
+    const TOKEN_TTL: Duration = Duration::from_secs(4);
+
+    let mut client = get_client().await?;
+    client.auth_enable().await?;
+
+    let mut client = get_auth_client(None).await?;
+    tokio::time::sleep(TOKEN_TTL).await;
+    // Must expire.
+    client
+        .get("key", None)
+        .await
+        .expect_err(&format!("The test expects that token TTL <= {TOKEN_TTL:?}"));
+
+    let options = Some(ConnectOptions::new().with_auto_token_refresh(true));
+
+    // Verify that a client with auto refresh outlives expiration.
+    let mut client = get_auth_client(options).await?;
+    client.get("key", None).await?;
+    tokio::time::sleep(TOKEN_TTL).await;
+    client.get("key", None).await?;
+    client.auth_disable().await?;
+
+    Ok(())
+}
+
 #[tokio::test]
 async fn test_role() -> Result<()> {
     let mut client = get_client().await?;
 
-    let role1 = "role1";
-    let role2 = "role2";
+    let role1 = "role1_";
+    let role2 = "role2_";
 
     let _ = client.role_delete(role1).await;
     let _ = client.role_delete(role2).await;

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -9,8 +9,10 @@ use etcd_client::{
     ProclaimOptions, PutOptions, ResignOptions, RoleRevokePermissionOptions, Txn, TxnOp,
     TxnOpResponse, UserAddOptions,
 };
+use serial_test::{parallel, serial};
 
 #[tokio::test]
+#[parallel]
 async fn test_put() -> Result<()> {
     let mut client = get_client().await?;
     client.put("put", "123", None).await?;
@@ -43,6 +45,7 @@ async fn test_put() -> Result<()> {
 }
 
 #[tokio::test]
+#[parallel]
 async fn test_get() -> Result<()> {
     let mut client = get_client().await?;
     client.put("get10", "10", None).await?;
@@ -94,6 +97,7 @@ async fn test_get() -> Result<()> {
 }
 
 #[tokio::test]
+#[parallel]
 async fn test_delete() -> Result<()> {
     let mut client = get_client().await?;
     client.put("del10", "10", None).await?;
@@ -144,6 +148,7 @@ async fn test_delete() -> Result<()> {
 }
 
 #[tokio::test]
+#[parallel]
 async fn test_compact() -> Result<()> {
     let mut client = get_client().await?;
     let rev0 = client
@@ -185,6 +190,7 @@ async fn test_compact() -> Result<()> {
 }
 
 #[tokio::test]
+#[parallel]
 async fn test_txn() -> Result<()> {
     let mut client = get_client().await?;
     client.put("txn01", "01", None).await?;
@@ -245,6 +251,7 @@ async fn test_txn() -> Result<()> {
 }
 
 #[tokio::test]
+#[parallel]
 async fn test_watch() -> Result<()> {
     let mut client = get_client().await?;
 
@@ -281,6 +288,7 @@ async fn test_watch() -> Result<()> {
 }
 
 #[tokio::test]
+#[parallel]
 async fn test_grant_revoke() -> Result<()> {
     let mut client = get_client().await?;
     let resp = client.lease_grant(123, None).await?;
@@ -291,6 +299,7 @@ async fn test_grant_revoke() -> Result<()> {
 }
 
 #[tokio::test]
+#[parallel]
 async fn test_keep_alive() -> Result<()> {
     let mut client = get_client().await?;
 
@@ -313,6 +322,7 @@ async fn test_keep_alive() -> Result<()> {
 }
 
 #[tokio::test]
+#[parallel]
 async fn test_time_to_live() -> Result<()> {
     let mut client = get_client().await?;
     let lease_id = 200;
@@ -331,6 +341,7 @@ async fn test_time_to_live() -> Result<()> {
 }
 
 #[tokio::test]
+#[parallel]
 async fn test_leases() -> Result<()> {
     let lease1 = 100;
     let lease2 = 101;
@@ -368,6 +379,7 @@ async fn test_leases() -> Result<()> {
 }
 
 #[tokio::test]
+#[parallel]
 async fn test_lock() -> Result<()> {
     let mut client = get_client().await?;
     let resp = client.lock("lock-test", None).await?;
@@ -379,8 +391,8 @@ async fn test_lock() -> Result<()> {
     Ok(())
 }
 
-#[ignore]
 #[tokio::test]
+#[serial]
 async fn test_auth() -> Result<()> {
     let mut client = get_client().await?;
     client.auth_enable().await?;
@@ -401,8 +413,8 @@ async fn test_auth() -> Result<()> {
     Ok(())
 }
 
-#[ignore]
 #[tokio::test]
+#[serial]
 async fn test_auth_refresh_token() -> Result<()> {
     const TOKEN_TTL: Duration = Duration::from_secs(4);
 
@@ -430,6 +442,7 @@ async fn test_auth_refresh_token() -> Result<()> {
 }
 
 #[tokio::test]
+#[parallel]
 async fn test_role() -> Result<()> {
     let mut client = get_client().await?;
 
@@ -526,6 +539,7 @@ async fn test_role() -> Result<()> {
 }
 
 #[tokio::test]
+#[parallel]
 async fn test_user() -> Result<()> {
     let name1 = "usr1";
     let password1 = "pwd1";
@@ -582,6 +596,7 @@ async fn test_user() -> Result<()> {
 }
 
 #[tokio::test]
+#[parallel]
 async fn test_alarm() -> Result<()> {
     let mut client = get_client().await?;
 
@@ -619,6 +634,7 @@ async fn test_alarm() -> Result<()> {
 }
 
 #[tokio::test]
+#[parallel]
 async fn test_status() -> Result<()> {
     let mut client = get_client().await?;
     let resp = client.status().await?;
@@ -629,6 +645,7 @@ async fn test_status() -> Result<()> {
 }
 
 #[tokio::test]
+#[parallel]
 async fn test_defragment() -> Result<()> {
     let mut client = get_client().await?;
     let resp = client.defragment().await?;
@@ -638,6 +655,7 @@ async fn test_defragment() -> Result<()> {
 }
 
 #[tokio::test]
+#[parallel]
 async fn test_hash() -> Result<()> {
     let mut client = get_client().await?;
     let resp = client.hash().await?;
@@ -648,6 +666,7 @@ async fn test_hash() -> Result<()> {
 }
 
 #[tokio::test]
+#[parallel]
 async fn test_hash_kv() -> Result<()> {
     let mut client = get_client().await?;
     let resp = client.hash_kv(0).await?;
@@ -659,6 +678,7 @@ async fn test_hash_kv() -> Result<()> {
 }
 
 #[tokio::test]
+#[parallel]
 async fn test_snapshot() -> Result<()> {
     let mut client = get_client().await?;
     let mut msg = client.snapshot().await?;
@@ -729,6 +749,7 @@ async fn test_move_leader() -> Result<()> {
 }
 
 #[tokio::test]
+#[parallel]
 async fn test_election() -> Result<()> {
     let mut client = get_client().await?;
     let resp = client.lease_grant(10, None).await?;
@@ -779,6 +800,7 @@ async fn test_election() -> Result<()> {
 }
 
 #[tokio::test]
+#[parallel]
 async fn test_remove_and_add_endpoint() -> Result<()> {
     let mut client = get_client().await?;
     client.put("endpoint", "add_remove", None).await?;

--- a/tests/testing.rs
+++ b/tests/testing.rs
@@ -1,13 +1,25 @@
-use etcd_client::{Client, Error};
+use etcd_client::{Client, ConnectOptions, Error};
 
 pub const DEFAULT_TEST_ENDPOINT: &str = "localhost:2379";
 
 pub type Result<T> = std::result::Result<T, Error>;
 
-/// Get client for testing.
-pub async fn get_client() -> Result<Client> {
+fn with_common_options(options: ConnectOptions) -> ConnectOptions {
     // Require a leader be present -- with only a single node, this
     // should never fail.
-    let options = etcd_client::ConnectOptions::new().with_require_leader(true);
+    options.with_require_leader(true)
+}
+
+/// Get client for testing.
+pub async fn get_client() -> Result<Client> {
+    let options = with_common_options(ConnectOptions::default());
+    Client::connect([DEFAULT_TEST_ENDPOINT], Some(options)).await
+}
+
+/// Get a testing client with auth enabled.
+#[allow(dead_code)]
+pub async fn get_auth_client(options: Option<ConnectOptions>) -> Result<Client> {
+    let options = with_common_options(options.unwrap_or_default())
+        .with_user("root".to_owned(), "rootpwd".to_owned());
     Client::connect([DEFAULT_TEST_ENDPOINT], Some(options)).await
 }


### PR DESCRIPTION
Add an opt-in mechanism to keep authentication tokens up to date without changing the default behavior.

When a request fails with a token-expiration error, the mechanism refreshes the token and retries the request. Retrying requires cloning the request, so the feature remains optional.

The mechanism supports all clients. It introduces a dispatching struct because the transport channel cannot be wrapped directly in middleware: generic requests may be streaming and therefore cannot always be cloned.

Based on #45